### PR TITLE
LP-84 integrate user authorization with payments

### DIFF
--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/auth/service/UserService.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/auth/service/UserService.java
@@ -59,9 +59,12 @@ public class UserService implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        User user = userRepository.findByEmail(username)
-                .orElseThrow(() -> new UsernameNotFoundException(username + " not found!"));
+        User user = findUserByEmail(username);
         return userConverter.convertToUserDetails(user);
     }
 
+    public User findUserByEmail(String email) {
+        return userRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException(email + " not found!"));
+    }
 }

--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/payment/facade/PaymentFacade.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/payment/facade/PaymentFacade.java
@@ -38,7 +38,8 @@ public class PaymentFacade {
                   PaymentDataService paymentDataService,
                   NodeDetailsService nodeDetailsService,
                   TokenService tokenService,
-                  PaymentSocketController paymentSocketController, UserService userService) {
+                  PaymentSocketController paymentSocketController,
+                  UserService userService) {
         this.invoiceService = invoiceService;
         this.propertyService = propertyService;
         this.paymentDataService = paymentDataService;

--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/payment/model/PaymentInfo.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/payment/model/PaymentInfo.java
@@ -4,7 +4,7 @@ import lombok.Builder;
 import lombok.Getter;
 import pl.edu.pjatk.lnpayments.webservice.payment.model.entity.Payment;
 
-import java.util.List;
+import java.util.Collection;
 
 @Getter
 @Builder
@@ -13,5 +13,5 @@ public class PaymentInfo {
     private int price;
     private String description;
     private String nodeUrl;
-    private List<Payment> pendingPayments;
+    private Collection<Payment> pendingPayments;
 }

--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/payment/model/entity/Payment.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/payment/model/entity/Payment.java
@@ -3,6 +3,7 @@ package pl.edu.pjatk.lnpayments.webservice.payment.model.entity;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import pl.edu.pjatk.lnpayments.webservice.common.entity.User;
 
 import javax.persistence.*;
 import java.time.Instant;
@@ -27,20 +28,25 @@ public class Payment {
     @Enumerated(EnumType.STRING)
     private PaymentStatus status;
     @OneToMany(cascade = CascadeType.ALL)
-    @JoinColumn(name = "payment_id")
+    @JoinColumn
     private final Collection<Token> tokens = new HashSet<>();
+    @ManyToOne
+    @JoinColumn
+    private User user;
 
     public Payment(String paymentRequest,
                    int numberOfTokens,
                    int price,
                    int expiryInSeconds,
-                   PaymentStatus paymentStatus) {
+                   PaymentStatus paymentStatus,
+                   User user) {
         this.paymentRequest = paymentRequest;
         this.numberOfTokens = numberOfTokens;
         this.price = price;
         this.date = Instant.now();
         this.expiry = date.plusSeconds(expiryInSeconds);
         this.status = paymentStatus;
+        this.user = user;
     }
 
     public void assignTokens(Collection<Token> tokens) {

--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/payment/repository/PaymentRepository.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/payment/repository/PaymentRepository.java
@@ -1,13 +1,19 @@
 package pl.edu.pjatk.lnpayments.webservice.payment.repository;
 
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import pl.edu.pjatk.lnpayments.webservice.payment.model.entity.Payment;
+import pl.edu.pjatk.lnpayments.webservice.payment.model.entity.PaymentStatus;
 
+import java.util.Collection;
 import java.util.Optional;
 
 @Repository
 public interface PaymentRepository extends CrudRepository<Payment, Long> {
 
     Optional<Payment> findPaymentByPaymentRequest(String paymentRequest);
+
+    Collection<Payment> findPendingPaymentsByUserEmailAndStatus(@Param("email") String email,
+                                                                @Param("status") PaymentStatus status);
 }

--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/payment/resource/PaymentResource.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/payment/resource/PaymentResource.java
@@ -14,6 +14,9 @@ import pl.edu.pjatk.lnpayments.webservice.payment.resource.dto.PaymentInfoRespon
 
 import javax.validation.Valid;
 
+import java.security.Principal;
+import java.util.Optional;
+
 import static pl.edu.pjatk.lnpayments.webservice.common.Constants.INFO_PATH;
 import static pl.edu.pjatk.lnpayments.webservice.common.Constants.PAYMENTS_PATH;
 
@@ -35,16 +38,16 @@ public class PaymentResource {
     }
 
     @GetMapping(INFO_PATH)
-    public ResponseEntity<?> paymentInfo() {
-        PaymentInfo paymentInfo = paymentFacade.buildInfoResponse();
+    public ResponseEntity<?> paymentInfo(Principal principal) {
+        PaymentInfo paymentInfo = paymentFacade.buildInfoResponse(Optional.of(principal.getName()));
         PaymentInfoResponse paymentInfoResponse = paymentInfoConverter.convertToDto(paymentInfo);
         return ResponseEntity.ok(paymentInfoResponse);
     }
 
     @PostMapping
     public ResponseEntity<PaymentDetailsResponse> createPayment(
-            @RequestBody @Valid PaymentDetailsRequest paymentDetailsRequest) {
-        Payment payment = paymentFacade.createNewPayment(paymentDetailsRequest);
+            @RequestBody @Valid PaymentDetailsRequest paymentDetailsRequest, Principal principal) {
+        Payment payment = paymentFacade.createNewPayment(paymentDetailsRequest, principal.getName());
         PaymentDetailsResponse response = paymentDetailsConverter.convertToDto(payment);
         return ResponseEntity.ok(response);
     }

--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/payment/resource/PaymentResource.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/payment/resource/PaymentResource.java
@@ -39,7 +39,7 @@ public class PaymentResource {
 
     @GetMapping(INFO_PATH)
     public ResponseEntity<?> paymentInfo(Principal principal) {
-        PaymentInfo paymentInfo = paymentFacade.buildInfoResponse(Optional.of(principal.getName()));
+        PaymentInfo paymentInfo = paymentFacade.buildInfoResponse(Optional.ofNullable(principal.getName()));
         PaymentInfoResponse paymentInfoResponse = paymentInfoConverter.convertToDto(paymentInfo);
         return ResponseEntity.ok(paymentInfoResponse);
     }

--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/payment/resource/converter/PaymentInfoConverter.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/payment/resource/converter/PaymentInfoConverter.java
@@ -2,12 +2,12 @@ package pl.edu.pjatk.lnpayments.webservice.payment.resource.converter;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import pl.edu.pjatk.lnpayments.webservice.payment.resource.dto.PaymentDetailsResponse;
 import pl.edu.pjatk.lnpayments.webservice.payment.model.PaymentInfo;
-import pl.edu.pjatk.lnpayments.webservice.payment.resource.dto.PaymentInfoResponse;
 import pl.edu.pjatk.lnpayments.webservice.payment.model.entity.Payment;
+import pl.edu.pjatk.lnpayments.webservice.payment.resource.dto.PaymentDetailsResponse;
+import pl.edu.pjatk.lnpayments.webservice.payment.resource.dto.PaymentInfoResponse;
 
-import java.util.List;
+import java.util.Collection;
 import java.util.stream.Collectors;
 
 @Service
@@ -29,7 +29,7 @@ public class PaymentInfoConverter {
                 .build();
     }
 
-    private List<PaymentDetailsResponse> mapPaymentToResponse(List<Payment> paymentList) {
+    private Collection<PaymentDetailsResponse> mapPaymentToResponse(Collection<Payment> paymentList) {
         return paymentList.stream()
                 .map(paymentDetailsConverter::convertToDto)
                 .collect(Collectors.toList());

--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/payment/resource/dto/PaymentDetailsRequest.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/payment/resource/dto/PaymentDetailsRequest.java
@@ -4,7 +4,6 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.annotation.Nullable;
 import javax.validation.Valid;
 import javax.validation.constraints.Min;
 
@@ -16,7 +15,5 @@ public class PaymentDetailsRequest {
 
     @Min(1)
     private int numberOfTokens;
-    @Nullable
-    private String email;
 
 }

--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/payment/resource/dto/PaymentInfoResponse.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/payment/resource/dto/PaymentInfoResponse.java
@@ -3,7 +3,7 @@ package pl.edu.pjatk.lnpayments.webservice.payment.resource.dto;
 import lombok.Builder;
 import lombok.Getter;
 
-import java.util.List;
+import java.util.Collection;
 
 @Getter
 @Builder
@@ -12,5 +12,5 @@ public class PaymentInfoResponse {
     private int price;
     private String description;
     private String nodeUrl;
-    private List<PaymentDetailsResponse> pendingPayments;
+    private Collection<PaymentDetailsResponse> pendingPayments;
 }

--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/payment/service/PaymentDataService.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/payment/service/PaymentDataService.java
@@ -4,10 +4,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import pl.edu.pjatk.lnpayments.webservice.payment.exception.InconsistentDataException;
 import pl.edu.pjatk.lnpayments.webservice.payment.model.entity.Payment;
+import pl.edu.pjatk.lnpayments.webservice.payment.model.entity.PaymentStatus;
 import pl.edu.pjatk.lnpayments.webservice.payment.repository.PaymentRepository;
 
-import java.util.Collections;
-import java.util.List;
+import java.util.Collection;
 
 @Service
 public class PaymentDataService {
@@ -23,9 +23,8 @@ public class PaymentDataService {
         return paymentRepository.save(payment);
     }
 
-    public List<Payment> findPendingPaymentsByUser() {
-        //TODO implement, when we have a way to authenticate users
-        return Collections.emptyList();
+    public Collection<Payment> findPendingPaymentsByUser(String email) {
+        return paymentRepository.findPendingPaymentsByUserEmailAndStatus(email, PaymentStatus.PENDING);
     }
 
     public Payment findPaymentByRequest(String paymentRequest) {

--- a/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/helper/factory/UserFactory.java
+++ b/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/helper/factory/UserFactory.java
@@ -1,0 +1,24 @@
+package pl.edu.pjatk.lnpayments.webservice.helper.factory;
+
+import pl.edu.pjatk.lnpayments.webservice.common.entity.Role;
+import pl.edu.pjatk.lnpayments.webservice.common.entity.StandardUser;
+import pl.edu.pjatk.lnpayments.webservice.common.entity.User;
+
+public class UserFactory {
+
+    private UserFactory() {
+    }
+
+    public static User createUser(String email) {
+        return new User(email) {
+            @Override
+            public Role getRole() {
+                return Role.ROLE_USER;
+            }
+        };
+    }
+
+    public static User createStandardUser(String email) {
+        return new StandardUser(email, "asd", "asd");
+    }
+}

--- a/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/payment/facade/PaymentFacadeTest.java
+++ b/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/payment/facade/PaymentFacadeTest.java
@@ -7,8 +7,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import pl.edu.pjatk.lnpayments.webservice.common.entity.Role;
-import pl.edu.pjatk.lnpayments.webservice.common.entity.User;
+import pl.edu.pjatk.lnpayments.webservice.auth.service.UserService;
 import pl.edu.pjatk.lnpayments.webservice.common.service.PropertyService;
 import pl.edu.pjatk.lnpayments.webservice.payment.model.PaymentInfo;
 import pl.edu.pjatk.lnpayments.webservice.payment.model.entity.Payment;
@@ -22,11 +21,13 @@ import pl.edu.pjatk.lnpayments.webservice.payment.service.PaymentDataService;
 import pl.edu.pjatk.lnpayments.webservice.payment.service.TokenService;
 
 import java.util.Collections;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static pl.edu.pjatk.lnpayments.webservice.helper.factory.UserFactory.createUser;
 
 @ExtendWith(MockitoExtension.class)
 class PaymentFacadeTest {
@@ -49,17 +50,35 @@ class PaymentFacadeTest {
     @Mock
     private TokenService tokenService;
 
+    @Mock
+    private UserService userService;
+
     @InjectMocks
     private PaymentFacade paymentFacade;
 
     @Test
     void shouldBuildPaymentInfo() {
-        when(paymentDataService.findPendingPaymentsByUser(null)).thenReturn(Collections.emptyList());
+        String email = "test@test.pl";
+        when(paymentDataService.findPendingPaymentsByUser(email)).thenReturn(Collections.emptyList());
         when(nodeDetailsService.getNodeUrl()).thenReturn("node_url");
         when(propertyService.getPrice()).thenReturn(1);
         when(propertyService.getDescription()).thenReturn("description");
 
-        PaymentInfo paymentInfo = paymentFacade.buildInfoResponse(null);
+        PaymentInfo paymentInfo = paymentFacade.buildInfoResponse(Optional.of(email));
+
+        assertThat(paymentInfo.getPendingPayments()).isEmpty();
+        assertThat(paymentInfo.getPrice()).isEqualTo(1);
+        assertThat(paymentInfo.getNodeUrl()).isEqualTo("node_url");
+        assertThat(paymentInfo.getDescription()).isEqualTo("description");
+    }
+
+    @Test
+    void shouldReturnInfoWhenNoEmailProvided() {
+        when(nodeDetailsService.getNodeUrl()).thenReturn("node_url");
+        when(propertyService.getPrice()).thenReturn(1);
+        when(propertyService.getDescription()).thenReturn("description");
+
+        PaymentInfo paymentInfo = paymentFacade.buildInfoResponse(Optional.empty());
 
         assertThat(paymentInfo.getPendingPayments()).isEmpty();
         assertThat(paymentInfo.getPrice()).isEqualTo(1);
@@ -69,18 +88,19 @@ class PaymentFacadeTest {
 
     @Test
     void shouldCreatePaymentForValidRequest() {
-        PaymentDetailsRequest request = new PaymentDetailsRequest(1, "email");
+        PaymentDetailsRequest request = new PaymentDetailsRequest(1);
         when(propertyService.getPrice()).thenReturn(1);
         when(propertyService.getInvoiceMemo()).thenReturn("memo");
         when(propertyService.getPaymentExpiryInSeconds()).thenReturn(100);
         when(paymentDataService.savePayment(any(Payment.class))).then(AdditionalAnswers.returnsFirstArg());
         when(invoiceService.createInvoice(anyInt(), anyInt(), anyInt(), any())).thenReturn("invoice");
 
-        Payment response = paymentFacade.createNewPayment(request, "");
+        Payment response = paymentFacade.createNewPayment(request, "test");
 
         assertThat(response.getPaymentRequest()).isEqualTo("invoice");
         assertThat(response.getStatus()).isEqualTo(PaymentStatus.PENDING);
         assertThat(response.getDate()).isBefore(response.getExpiry());
+        verify(paymentDataService).savePayment(any());
     }
 
     @Test
@@ -99,12 +119,4 @@ class PaymentFacadeTest {
         assertThat(captor.getValue()).hasSize(8);
     }
 
-    private User createUser(String email) {
-        return new User(email) {
-            @Override
-            public Role getRole() {
-                return Role.ROLE_USER;
-            }
-        };
-    }
 }

--- a/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/payment/resource/PaymentResourceIntegrationTest.java
+++ b/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/payment/resource/PaymentResourceIntegrationTest.java
@@ -2,40 +2,83 @@ package pl.edu.pjatk.lnpayments.webservice.payment.resource;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jayway.jsonpath.JsonPath;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
+import pl.edu.pjatk.lnpayments.webservice.auth.repository.UserRepository;
 import pl.edu.pjatk.lnpayments.webservice.helper.config.BaseIntegrationTest;
 import pl.edu.pjatk.lnpayments.webservice.helper.config.IntegrationTestConfiguration;
+import pl.edu.pjatk.lnpayments.webservice.payment.repository.PaymentRepository;
 import pl.edu.pjatk.lnpayments.webservice.payment.resource.dto.PaymentDetailsRequest;
 
+import java.security.Principal;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static pl.edu.pjatk.lnpayments.webservice.helper.factory.UserFactory.createStandardUser;
 
 @ActiveProfiles("test")
 @AutoConfigureMockMvc(addFilters = false)
 @SpringBootTest(classes = IntegrationTestConfiguration.class)
 class PaymentResourceIntegrationTest extends BaseIntegrationTest {
 
+    private final static String EMAIL = "test@test.pl";
+
     @Autowired
     private MockMvc mockMvc;
+
+    @MockBean
+    private Principal principal;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PaymentRepository paymentRepository;
+
+    @BeforeEach
+    void setUp() {
+        when(principal.getName()).thenReturn(EMAIL);
+    }
+
+    @AfterEach
+    void tearDown() {
+        paymentRepository.deleteAll();
+        userRepository.deleteAll();
+    }
 
     @Nested
     class PaymentInfoIntegrationTest {
 
         @Test
         void shouldReturnOkAndCorrectResponse() throws Exception {
+            userRepository.save(createStandardUser(EMAIL));
             String jsonContent = getJsonResponse("integration/payment/response/profileinfo-GET-valid.json");
-            mockMvc.perform(get("/payments/info"))
+            mockMvc.perform(get("/payments/info")
+                            .principal(principal))
+                    .andExpect(status().isOk())
+                    .andExpect(content().json(jsonContent));
+        }
+
+        @Test
+        void shouldReturnOkWhenUserNotAuthorized() throws Exception {
+            when(principal.getName()).thenReturn(null);
+            String jsonContent = getJsonResponse("integration/payment/response/profileinfo-GET-valid.json");
+            mockMvc.perform(get("/payments/info")
+                            .principal(principal))
                     .andExpect(status().isOk())
                     .andExpect(content().json(jsonContent));
         }
@@ -46,8 +89,10 @@ class PaymentResourceIntegrationTest extends BaseIntegrationTest {
 
         @Test
         void shouldReturnOkForProperRequest() throws Exception {
+            userRepository.save(createStandardUser(EMAIL));
             String request = getJsonResponse("integration/payment/request/details-POST-valid.json");
             MvcResult mvcResult = mockMvc.perform(post("/payments")
+                            .principal(principal)
                             .content(request)
                             .contentType(MediaType.APPLICATION_JSON))
                     .andExpect(status().isOk())
@@ -58,23 +103,12 @@ class PaymentResourceIntegrationTest extends BaseIntegrationTest {
 
         @Test
         void shouldReturn404WhenInvalidTokenNumberProvided() throws Exception {
-            PaymentDetailsRequest request = new PaymentDetailsRequest(-1, "test@test.pl");
+            PaymentDetailsRequest request = new PaymentDetailsRequest(-1);
             mockMvc.perform(post("/payments")
                             .content(new ObjectMapper().writeValueAsString(request))
+                            .principal(principal)
                             .contentType(MediaType.APPLICATION_JSON))
                     .andExpect(status().isBadRequest());
         }
-
-        @Test
-        void shouldReturnOkWhenNoEmail() throws Exception {
-            PaymentDetailsRequest request = new PaymentDetailsRequest(1, null);
-            mockMvc.perform(post("/payments")
-                            .content(new ObjectMapper().writeValueAsString(request))
-                            .contentType(MediaType.APPLICATION_JSON))
-                    .andExpect(status().isOk());
-        }
-
     }
-
-
 }

--- a/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/payment/resource/PaymentResourceTest.java
+++ b/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/payment/resource/PaymentResourceTest.java
@@ -35,7 +35,7 @@ class PaymentResourceTest {
 
         @Test
         void shouldReturnStatusOkWhenProperDataPassed() {
-            PaymentDetailsRequest request = new PaymentDetailsRequest(1, "email");
+            PaymentDetailsRequest request = new PaymentDetailsRequest(1);
 
             ResponseEntity<?> payment = paymentResource.createPayment(request, () -> null);
 
@@ -44,7 +44,7 @@ class PaymentResourceTest {
 
         @Test
         void shouldReturnStatusOKWhenNoEmailSpecified() {
-            PaymentDetailsRequest request = new PaymentDetailsRequest(1, null);
+            PaymentDetailsRequest request = new PaymentDetailsRequest(1);
 
             ResponseEntity<?> payment = paymentResource.createPayment(request, () -> null);
 
@@ -57,7 +57,7 @@ class PaymentResourceTest {
 
         @Test
         void shouldReturnOkForAnyRequest() {
-            ResponseEntity<?> payment = paymentResource.paymentInfo(null);
+            ResponseEntity<?> payment = paymentResource.paymentInfo(() -> "test");
 
             assertThat(payment.getStatusCode()).isEqualTo(HttpStatus.OK);
         }

--- a/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/payment/resource/PaymentResourceTest.java
+++ b/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/payment/resource/PaymentResourceTest.java
@@ -37,7 +37,7 @@ class PaymentResourceTest {
         void shouldReturnStatusOkWhenProperDataPassed() {
             PaymentDetailsRequest request = new PaymentDetailsRequest(1, "email");
 
-            ResponseEntity<?> payment = paymentResource.createPayment(request);
+            ResponseEntity<?> payment = paymentResource.createPayment(request, () -> null);
 
             assertThat(payment.getStatusCode()).isEqualTo(HttpStatus.OK);
         }
@@ -46,7 +46,7 @@ class PaymentResourceTest {
         void shouldReturnStatusOKWhenNoEmailSpecified() {
             PaymentDetailsRequest request = new PaymentDetailsRequest(1, null);
 
-            ResponseEntity<?> payment = paymentResource.createPayment(request);
+            ResponseEntity<?> payment = paymentResource.createPayment(request, () -> null);
 
             assertThat(payment.getStatusCode()).isEqualTo(HttpStatus.OK);
         }
@@ -57,7 +57,7 @@ class PaymentResourceTest {
 
         @Test
         void shouldReturnOkForAnyRequest() {
-            ResponseEntity<?> payment = paymentResource.paymentInfo();
+            ResponseEntity<?> payment = paymentResource.paymentInfo(null);
 
             assertThat(payment.getStatusCode()).isEqualTo(HttpStatus.OK);
         }

--- a/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/payment/resource/PaymentSocketControllerIntegrationTest.java
+++ b/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/payment/resource/PaymentSocketControllerIntegrationTest.java
@@ -68,7 +68,7 @@ class PaymentSocketControllerIntegrationTest extends BaseIntegrationTest {
         Invoice invoice = new Invoice();
         invoice.setState(Invoice.InvoiceState.SETTLED);
         invoice.setPaymentRequest(paymentRequest);
-        Payment payment = new Payment(paymentRequest, 1, 1, 60, PaymentStatus.PENDING);
+        Payment payment = new Payment(paymentRequest, 1, 1, 60, PaymentStatus.PENDING, null);
         paymentDataService.savePayment(payment);
         StompSession stompSession = webSocketStompClient.connect(String.format("ws://localhost:%d/api/payment", port), new StompSessionHandlerAdapter() {}).get(1, SECONDS);
         stompSession.subscribe("/topic/34079ad7", new TokenResponseFrameHandler());

--- a/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/payment/resource/converter/PaymentDetailsConverterTest.java
+++ b/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/payment/resource/converter/PaymentDetailsConverterTest.java
@@ -13,7 +13,7 @@ class PaymentDetailsConverterTest {
 
     @Test
     void shouldConvertToDto() {
-        Payment payment = new Payment("123", 1, 1, 123, PaymentStatus.PENDING);
+        Payment payment = new Payment("123", 1, 1, 123, PaymentStatus.PENDING, null);
 
         PaymentDetailsResponse response = paymentDetailsConverter.convertToDto(payment);
 

--- a/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/payment/service/PaymentDataServiceTest.java
+++ b/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/payment/service/PaymentDataServiceTest.java
@@ -10,7 +10,7 @@ import pl.edu.pjatk.lnpayments.webservice.payment.model.entity.Payment;
 import pl.edu.pjatk.lnpayments.webservice.payment.model.entity.PaymentStatus;
 import pl.edu.pjatk.lnpayments.webservice.payment.repository.PaymentRepository;
 
-import java.util.List;
+import java.util.Collection;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -33,7 +33,7 @@ class PaymentDataServiceTest {
 
     @Test
     void shouldSaveItemAndReturnCopy() {
-        Payment payment = new Payment("asd", 1, 1, 60, PaymentStatus.PENDING);
+        Payment payment = new Payment("asd", 1, 1, 60, PaymentStatus.PENDING, null);
         when(paymentRepository.save(payment)).thenReturn(payment);
 
         Payment returnedPayment = paymentDataService.savePayment(payment);
@@ -44,14 +44,14 @@ class PaymentDataServiceTest {
     @Test
     void shouldReturnEmptyListOfPendingTransactionWhenThereAreNone() {
         //TODO: implement in LP-xxx
-        List<Payment> payments = paymentDataService.findPendingPaymentsByUser();
+        Collection<Payment> payments = paymentDataService.findPendingPaymentsByUser(null);
         assertThat(payments).isEmpty();
     }
 
     @Test
     void shouldFindPaymentById() {
         String paymentRequest = "asd";
-        Payment payment = new Payment(paymentRequest, 1, 1, 60, PaymentStatus.PENDING);
+        Payment payment = new Payment(paymentRequest, 1, 1, 60, PaymentStatus.PENDING, null);
         when(paymentRepository.findPaymentByPaymentRequest(paymentRequest)).thenReturn(Optional.of(payment));
 
         Payment result = paymentDataService.findPaymentByRequest(paymentRequest);

--- a/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/payment/service/TokenServiceTest.java
+++ b/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/payment/service/TokenServiceTest.java
@@ -16,7 +16,7 @@ class TokenServiceTest {
 
     @Test
     void shouldGenerateCorrectNumberOfUniqueTokens() {
-        Payment payment = new Payment("asd", 5, 5, 5, PaymentStatus.PENDING);
+        Payment payment = new Payment("asd", 5, 5, 5, PaymentStatus.PENDING, null);
 
         Collection<Token> tokens = tokenService.generateTokens(payment);
 


### PR DESCRIPTION
Link to the Jira issue
https://candybear.atlassian.net/browse/LP-84

### Description

I have added authorization features to payments. Every payment is now associated with user. It can also handle payment requests from temporary users. Payment POST endpoint has been changed. Now it only takes numberOfTokens as parameter, as email is obtained from JWT Token (for temporary users it requires special request to /auth/temporary before /payments)

### How did I test it
Created unit, integration tests. Tested manually.
