### PR TITLE
LP-89 Save admin user at startup

### DIFF
--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/auth/converter/UserConverter.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/auth/converter/UserConverter.java
@@ -5,8 +5,10 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import pl.edu.pjatk.lnpayments.webservice.auth.model.UserDetailsImpl;
+import pl.edu.pjatk.lnpayments.webservice.auth.resource.dto.AdminRequest;
 import pl.edu.pjatk.lnpayments.webservice.auth.resource.dto.LoginResponse;
 import pl.edu.pjatk.lnpayments.webservice.auth.resource.dto.RegisterRequest;
+import pl.edu.pjatk.lnpayments.webservice.common.entity.AdminUser;
 import pl.edu.pjatk.lnpayments.webservice.common.entity.StandardUser;
 import pl.edu.pjatk.lnpayments.webservice.common.entity.User;
 
@@ -22,6 +24,14 @@ public class UserConverter {
 
     public StandardUser convertToEntity(RegisterRequest request) {
         return StandardUser.builder()
+                .fullName(request.getFullName())
+                .password(passwordEncoder.encode(request.getPassword()))
+                .email(request.getEmail())
+                .build();
+    }
+
+    public AdminUser convertToAdminEntity(AdminRequest request) {
+        return AdminUser.adminBuilder()
                 .fullName(request.getFullName())
                 .password(passwordEncoder.encode(request.getPassword()))
                 .email(request.getEmail())

--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/auth/resource/dto/AdminRequest.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/auth/resource/dto/AdminRequest.java
@@ -1,0 +1,11 @@
+package pl.edu.pjatk.lnpayments.webservice.auth.resource.dto;
+
+import lombok.Builder;
+
+public class AdminRequest extends RegisterRequest {
+
+    @Builder
+    public AdminRequest(String email, String fullName, String password) {
+        super(email, fullName, password);
+    }
+}

--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/auth/service/UserService.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/auth/service/UserService.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Service;
 import pl.edu.pjatk.lnpayments.webservice.auth.converter.UserConverter;
 import pl.edu.pjatk.lnpayments.webservice.auth.repository.StandardUserRepository;
 import pl.edu.pjatk.lnpayments.webservice.auth.repository.UserRepository;
+import pl.edu.pjatk.lnpayments.webservice.auth.resource.dto.AdminRequest;
 import pl.edu.pjatk.lnpayments.webservice.auth.resource.dto.LoginResponse;
 import pl.edu.pjatk.lnpayments.webservice.auth.resource.dto.RegisterRequest;
 import pl.edu.pjatk.lnpayments.webservice.common.entity.StandardUser;
@@ -35,12 +36,15 @@ public class UserService implements UserDetailsService {
 
     @Transactional
     public void createUser(RegisterRequest request) {
+        validateEmail(request.getEmail());
+        User user = userConverter.convertToEntity(request);
+        userRepository.save(user);
+    }
 
-        if (userRepository.existsByEmail(request.getEmail())) {
-            throw new ValidationException("User with mail " + request.getEmail() + " exists!");
-        }
-
-        StandardUser user = userConverter.convertToEntity(request);
+    @Transactional
+    public void createAdmin(AdminRequest request) {
+        validateEmail(request.getEmail());
+        User user = userConverter.convertToAdminEntity(request);
         userRepository.save(user);
     }
 
@@ -66,5 +70,11 @@ public class UserService implements UserDetailsService {
     public User findUserByEmail(String email) {
         return userRepository.findByEmail(email)
                 .orElseThrow(() -> new UsernameNotFoundException(email + " not found!"));
+    }
+
+    private void validateEmail(String email) {
+        if (userRepository.existsByEmail(email)) {
+            throw new ValidationException("User with mail " + email + " exists!");
+        }
     }
 }

--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/common/Constants.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/common/Constants.java
@@ -11,6 +11,9 @@ public class Constants {
     public static final String TEMPORARY_PATH = "/temporary";
     public static final String PAYMENTS_WS_PATH = "/payment";
 
+    public static final String ROOT_USER_EMAIL = "admin@admin.pl";
+    public static final String ROOT_USER_PASSWORD = "admin";
+
     private Constants() {}
 
 }

--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/common/entity/AdminUser.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/common/entity/AdminUser.java
@@ -1,0 +1,25 @@
+package pl.edu.pjatk.lnpayments.webservice.common.entity;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.persistence.Entity;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+public class AdminUser extends StandardUser {
+
+    @Builder(builderMethodName = "adminBuilder")
+    public AdminUser(String email, String fullName, String password) {
+        super(email, fullName, password);
+    }
+
+    @Override
+    public Role getRole() {
+        return Role.ROLE_ADMIN;
+    }
+}

--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/common/startup/InitialDataLoader.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/common/startup/InitialDataLoader.java
@@ -1,0 +1,44 @@
+package pl.edu.pjatk.lnpayments.webservice.common.startup;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+import pl.edu.pjatk.lnpayments.webservice.auth.resource.dto.AdminRequest;
+import pl.edu.pjatk.lnpayments.webservice.auth.service.UserService;
+
+import javax.validation.ValidationException;
+
+import static pl.edu.pjatk.lnpayments.webservice.common.Constants.ROOT_USER_EMAIL;
+import static pl.edu.pjatk.lnpayments.webservice.common.Constants.ROOT_USER_PASSWORD;
+
+@Slf4j
+@Component
+class InitialDataLoader implements ApplicationRunner {
+
+    private final UserService userService;
+
+    @Autowired
+    public InitialDataLoader(UserService userService) {
+        this.userService = userService;
+    }
+
+    @Override
+    public void run(ApplicationArguments args) {
+        String password = ROOT_USER_PASSWORD;
+        String email = ROOT_USER_EMAIL;
+        AdminRequest request = AdminRequest.builder()
+                .fullName("admin")
+                .password(password)
+                .email(email)
+                .build();
+        try {
+            userService.createAdmin(request);
+            log.info("Initial user has been added with email {} and password {}", email, password);
+        } catch (ValidationException e) {
+            //TODO Refactor when initial configuration is implemented (eg. check if server was already initialized)
+            log.warn("Unable to create initial admin user: " + e.getMessage());
+        }
+    }
+}

--- a/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/auth/converter/UserConverterTest.java
+++ b/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/auth/converter/UserConverterTest.java
@@ -7,12 +7,10 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import pl.edu.pjatk.lnpayments.webservice.auth.resource.dto.AdminRequest;
 import pl.edu.pjatk.lnpayments.webservice.auth.resource.dto.LoginResponse;
 import pl.edu.pjatk.lnpayments.webservice.auth.resource.dto.RegisterRequest;
-import pl.edu.pjatk.lnpayments.webservice.common.entity.Role;
-import pl.edu.pjatk.lnpayments.webservice.common.entity.StandardUser;
-import pl.edu.pjatk.lnpayments.webservice.common.entity.TemporaryUser;
-import pl.edu.pjatk.lnpayments.webservice.common.entity.User;
+import pl.edu.pjatk.lnpayments.webservice.common.entity.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -76,5 +74,19 @@ class UserConverterTest {
         assertThat(userDetails.getPassword()).isEqualTo(null);
         assertThat(userDetails.getAuthorities()).hasSize(1);
         assertThat(userDetails.getAuthorities().contains(Role.ROLE_TEMPORARY)).isTrue();
+    }
+
+    @Test
+    void shouldConvertToAdminRequest() {
+        when(passwordEncoder.encode(anyString())).thenReturn("encoded_pass");
+        AdminRequest request = new AdminRequest("test@test.pl", "test", "pass");
+
+        AdminUser user = userConverter.convertToAdminEntity(request);
+
+        assertThat(user.getEmail()).isEqualTo("test@test.pl");
+        assertThat(user.getPassword()).isEqualTo("encoded_pass");
+        assertThat(user.getFullName()).isEqualTo("test");
+        assertThat(user.getRole()).isEqualTo(Role.ROLE_ADMIN);
+        verify(passwordEncoder).encode(anyString());
     }
 }

--- a/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/common/startup/InitialDataLoaderTest.java
+++ b/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/common/startup/InitialDataLoaderTest.java
@@ -1,0 +1,71 @@
+package pl.edu.pjatk.lnpayments.webservice.common.startup;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import org.assertj.core.groups.Tuple;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
+import pl.edu.pjatk.lnpayments.webservice.auth.resource.dto.AdminRequest;
+import pl.edu.pjatk.lnpayments.webservice.auth.service.UserService;
+
+import javax.validation.ValidationException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static pl.edu.pjatk.lnpayments.webservice.common.Constants.ROOT_USER_EMAIL;
+import static pl.edu.pjatk.lnpayments.webservice.common.Constants.ROOT_USER_PASSWORD;
+
+@ExtendWith(MockitoExtension.class)
+class InitialDataLoaderTest {
+
+    @Mock
+    private UserService userService;
+
+    @InjectMocks
+    private InitialDataLoader initialDataLoader;
+
+    private ListAppender<ILoggingEvent> logAppender;
+
+    @BeforeEach
+    void setUp() {
+        logAppender = new ListAppender<>();
+        logAppender.start();
+        ((Logger) LoggerFactory.getLogger(InitialDataLoader.class)).addAppender(logAppender);
+    }
+
+    @Test
+    void shouldInvokeServiceAndLogInfo() {
+        initialDataLoader.run(null);
+
+        ArgumentCaptor<AdminRequest> captor = ArgumentCaptor.forClass(AdminRequest.class);
+        verify(userService).createAdmin(captor.capture());
+        AdminRequest request = captor.getValue();
+        assertThat(request.getEmail()).isEqualTo(ROOT_USER_EMAIL);
+        assertThat(request.getPassword()).isEqualTo(ROOT_USER_PASSWORD);
+        assertThat(logAppender.list)
+                .extracting(ILoggingEvent::getMessage, ILoggingEvent::getLevel)
+                .contains(Tuple.tuple("Initial user has been added with email {} and password {}", Level.INFO));
+    }
+
+    @Test
+    void shouldLogWarningWhenUserAlreadyExists() {
+        doThrow(ValidationException.class).when(userService).createAdmin(any());
+
+        initialDataLoader.run(null);
+
+        verify(userService).createAdmin(any());
+        assertThat(logAppender.list)
+                .extracting(ILoggingEvent::getMessage, ILoggingEvent::getLevel)
+                .contains(Tuple.tuple("Unable to create initial admin user: null", Level.WARN));
+    }
+}


### PR DESCRIPTION
Link to the Jira issue
https://candybear.atlassian.net/browse/LP-89

### Description

Admin user is now created on server startup. Credentials can be found in Constants class.

### How did I test it

User is saved in db. Wrote unit tests.
