### PR TITLE
LP-90  Add endpoint for adding and querying admins

### DIFF
--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/admin/converter/AdminConverter.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/admin/converter/AdminConverter.java
@@ -1,0 +1,39 @@
+package pl.edu.pjatk.lnpayments.webservice.admin.converter;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import pl.edu.pjatk.lnpayments.webservice.admin.resource.dto.AdminRequest;
+import pl.edu.pjatk.lnpayments.webservice.admin.resource.dto.AdminResponse;
+import pl.edu.pjatk.lnpayments.webservice.common.entity.AdminUser;
+
+@Service
+public class AdminConverter {
+
+    private final PasswordEncoder passwordEncoder;
+
+    @Autowired
+    public AdminConverter(PasswordEncoder passwordEncoder) {
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    public AdminUser convertToEntity(AdminRequest request) {
+        return AdminUser.adminBuilder()
+                .fullName(request.getFullName())
+                .password(passwordEncoder.encode(request.getPassword()))
+                .email(request.getEmail())
+                .build();
+    }
+
+    public AdminResponse convertToDto(AdminUser adminUser) {
+        return AdminResponse.builder()
+                .fullName(adminUser.getFullName())
+                .email(adminUser.getEmail())
+                .build();
+    }
+
+    public Page<AdminResponse> convertAllToDto(Page<AdminUser> admins) {
+        return admins.map(this::convertToDto);
+    }
+}

--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/admin/resource/AdminResource.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/admin/resource/AdminResource.java
@@ -1,0 +1,39 @@
+package pl.edu.pjatk.lnpayments.webservice.admin.resource;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import pl.edu.pjatk.lnpayments.webservice.admin.resource.dto.AdminRequest;
+import pl.edu.pjatk.lnpayments.webservice.admin.resource.dto.AdminResponse;
+import pl.edu.pjatk.lnpayments.webservice.admin.service.AdminService;
+
+import javax.validation.Valid;
+
+import static pl.edu.pjatk.lnpayments.webservice.common.Constants.ADMIN_PATH;
+
+@RestController
+@RequestMapping(ADMIN_PATH)
+class AdminResource {
+
+    private final AdminService userService;
+
+    @Autowired
+    public AdminResource(AdminService userService) {
+        this.userService = userService;
+    }
+
+    @PostMapping
+    public ResponseEntity<?> addAdmin(@RequestBody @Valid AdminRequest adminRequest) {
+        userService.createAdmin(adminRequest);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @GetMapping
+    public ResponseEntity<Page<AdminResponse>> getAdmins(Pageable pageable) {
+        Page<AdminResponse> admins = userService.findAllAdmins(pageable);
+        return ResponseEntity.ok(admins);
+    }
+}

--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/admin/resource/dto/AdminRequest.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/admin/resource/dto/AdminRequest.java
@@ -1,7 +1,10 @@
-package pl.edu.pjatk.lnpayments.webservice.auth.resource.dto;
+package pl.edu.pjatk.lnpayments.webservice.admin.resource.dto;
 
 import lombok.Builder;
+import lombok.NoArgsConstructor;
+import pl.edu.pjatk.lnpayments.webservice.auth.resource.dto.RegisterRequest;
 
+@NoArgsConstructor
 public class AdminRequest extends RegisterRequest {
 
     @Builder

--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/admin/resource/dto/AdminResponse.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/admin/resource/dto/AdminResponse.java
@@ -1,0 +1,15 @@
+package pl.edu.pjatk.lnpayments.webservice.admin.resource.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+@AllArgsConstructor
+public class AdminResponse {
+
+    private String fullName;
+    private String email;
+
+}

--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/admin/service/AdminService.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/admin/service/AdminService.java
@@ -1,0 +1,42 @@
+package pl.edu.pjatk.lnpayments.webservice.admin.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import pl.edu.pjatk.lnpayments.webservice.admin.converter.AdminConverter;
+import pl.edu.pjatk.lnpayments.webservice.admin.resource.dto.AdminRequest;
+import pl.edu.pjatk.lnpayments.webservice.admin.resource.dto.AdminResponse;
+import pl.edu.pjatk.lnpayments.webservice.auth.repository.AdminUserRepository;
+import pl.edu.pjatk.lnpayments.webservice.common.entity.AdminUser;
+
+import javax.transaction.Transactional;
+import javax.validation.ValidationException;
+
+@Service
+public class AdminService {
+
+    private final AdminUserRepository adminUserRepository;
+    private final AdminConverter adminConverter;
+
+    @Autowired
+    public AdminService(AdminUserRepository adminUserRepository, AdminConverter adminConverter) {
+        this.adminUserRepository = adminUserRepository;
+        this.adminConverter = adminConverter;
+    }
+
+    @Transactional
+    public void createAdmin(AdminRequest request) {
+        String requestEmail = request.getEmail();
+        if (adminUserRepository.existsByEmail(requestEmail)) {
+            throw new ValidationException("User with mail " + requestEmail + " exists!");
+        }
+        AdminUser user = adminConverter.convertToEntity(request);
+        adminUserRepository.save(user);
+    }
+
+    public Page<AdminResponse> findAllAdmins(Pageable pageable) {
+        Page<AdminUser> admins = adminUserRepository.findAll(pageable);
+        return adminConverter.convertAllToDto(admins);
+    }
+}

--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/admin/startup/InitialAdminLoader.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/admin/startup/InitialAdminLoader.java
@@ -1,12 +1,13 @@
-package pl.edu.pjatk.lnpayments.webservice.common.startup;
+package pl.edu.pjatk.lnpayments.webservice.admin.startup;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
-import pl.edu.pjatk.lnpayments.webservice.auth.resource.dto.AdminRequest;
-import pl.edu.pjatk.lnpayments.webservice.auth.service.UserService;
+import pl.edu.pjatk.lnpayments.webservice.admin.service.AdminService;
+import pl.edu.pjatk.lnpayments.webservice.admin.resource.dto.AdminRequest;
 
 import javax.validation.ValidationException;
 
@@ -15,13 +16,14 @@ import static pl.edu.pjatk.lnpayments.webservice.common.Constants.ROOT_USER_PASS
 
 @Slf4j
 @Component
-class InitialDataLoader implements ApplicationRunner {
+@Profile("!test")
+class InitialAdminLoader implements ApplicationRunner {
 
-    private final UserService userService;
+    private final AdminService adminService;
 
     @Autowired
-    public InitialDataLoader(UserService userService) {
-        this.userService = userService;
+    public InitialAdminLoader(AdminService adminService) {
+        this.adminService = adminService;
     }
 
     @Override
@@ -34,7 +36,7 @@ class InitialDataLoader implements ApplicationRunner {
                 .email(email)
                 .build();
         try {
-            userService.createAdmin(request);
+            adminService.createAdmin(request);
             log.info("Initial user has been added with email {} and password {}", email, password);
         } catch (ValidationException e) {
             //TODO Refactor when initial configuration is implemented (eg. check if server was already initialized)

--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/auth/config/WebSecurityConfig.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/auth/config/WebSecurityConfig.java
@@ -17,6 +17,7 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.filter.CorsFilter;
 import pl.edu.pjatk.lnpayments.webservice.auth.filter.AuthTokenFilter;
+import pl.edu.pjatk.lnpayments.webservice.common.entity.Role;
 
 import static pl.edu.pjatk.lnpayments.webservice.common.Constants.*;
 
@@ -24,7 +25,7 @@ import static pl.edu.pjatk.lnpayments.webservice.common.Constants.*;
 @EnableWebSecurity
 class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 
-    private final String[] UNSECURED_PATHS = {
+    private final static String[] UNSECURED_PATHS = {
             AUTH_PATH + REGISTER_PATH,
             AUTH_PATH + LOGIN_PATH,
             AUTH_PATH + TEMPORARY_PATH,
@@ -33,6 +34,10 @@ class WebSecurityConfig extends WebSecurityConfigurerAdapter {
             "/v2/api-docs",
             "/swagger-ui/**",
             "/swagger-resources/**"
+    };
+
+    private final static String[] ADMIN_PATHS = {
+            AUTH_PATH + ADMIN_PATH
     };
 
     private final UserDetailsService userDetailsService;
@@ -61,6 +66,7 @@ class WebSecurityConfig extends WebSecurityConfigurerAdapter {
                 .exceptionHandling().authenticationEntryPoint(new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED)).and()
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS).and()
                 .authorizeRequests()
+                .antMatchers(ADMIN_PATHS).hasAuthority(Role.ROLE_ADMIN.toString())
                 .antMatchers(UNSECURED_PATHS).permitAll()
                 .anyRequest().authenticated().and()
                 .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);

--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/auth/converter/UserConverter.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/auth/converter/UserConverter.java
@@ -5,10 +5,8 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import pl.edu.pjatk.lnpayments.webservice.auth.model.UserDetailsImpl;
-import pl.edu.pjatk.lnpayments.webservice.auth.resource.dto.AdminRequest;
 import pl.edu.pjatk.lnpayments.webservice.auth.resource.dto.LoginResponse;
 import pl.edu.pjatk.lnpayments.webservice.auth.resource.dto.RegisterRequest;
-import pl.edu.pjatk.lnpayments.webservice.common.entity.AdminUser;
 import pl.edu.pjatk.lnpayments.webservice.common.entity.StandardUser;
 import pl.edu.pjatk.lnpayments.webservice.common.entity.User;
 
@@ -24,14 +22,6 @@ public class UserConverter {
 
     public StandardUser convertToEntity(RegisterRequest request) {
         return StandardUser.builder()
-                .fullName(request.getFullName())
-                .password(passwordEncoder.encode(request.getPassword()))
-                .email(request.getEmail())
-                .build();
-    }
-
-    public AdminUser convertToAdminEntity(AdminRequest request) {
-        return AdminUser.adminBuilder()
                 .fullName(request.getFullName())
                 .password(passwordEncoder.encode(request.getPassword()))
                 .email(request.getEmail())

--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/auth/repository/AdminUserRepository.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/auth/repository/AdminUserRepository.java
@@ -1,0 +1,9 @@
+package pl.edu.pjatk.lnpayments.webservice.auth.repository;
+
+import org.springframework.stereotype.Repository;
+import pl.edu.pjatk.lnpayments.webservice.common.entity.AdminUser;
+
+@Repository
+public interface AdminUserRepository extends BaseUserRepository<AdminUser> {
+
+}

--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/auth/repository/BaseUserRepository.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/auth/repository/BaseUserRepository.java
@@ -1,13 +1,13 @@
 package pl.edu.pjatk.lnpayments.webservice.auth.repository;
 
-import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.repository.NoRepositoryBean;
 import pl.edu.pjatk.lnpayments.webservice.common.entity.User;
 
 import java.util.Optional;
 
 @NoRepositoryBean
-public interface BaseUserRepository<T extends User> extends CrudRepository<T, Long> {
+public interface BaseUserRepository<T extends User> extends JpaRepository<T, Long> {
 
     Optional<T> findByEmail(String email);
 

--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/auth/service/UserService.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/auth/service/UserService.java
@@ -8,7 +8,6 @@ import org.springframework.stereotype.Service;
 import pl.edu.pjatk.lnpayments.webservice.auth.converter.UserConverter;
 import pl.edu.pjatk.lnpayments.webservice.auth.repository.StandardUserRepository;
 import pl.edu.pjatk.lnpayments.webservice.auth.repository.UserRepository;
-import pl.edu.pjatk.lnpayments.webservice.auth.resource.dto.AdminRequest;
 import pl.edu.pjatk.lnpayments.webservice.auth.resource.dto.LoginResponse;
 import pl.edu.pjatk.lnpayments.webservice.auth.resource.dto.RegisterRequest;
 import pl.edu.pjatk.lnpayments.webservice.common.entity.StandardUser;
@@ -38,13 +37,6 @@ public class UserService implements UserDetailsService {
     public void createUser(RegisterRequest request) {
         validateEmail(request.getEmail());
         User user = userConverter.convertToEntity(request);
-        userRepository.save(user);
-    }
-
-    @Transactional
-    public void createAdmin(AdminRequest request) {
-        validateEmail(request.getEmail());
-        User user = userConverter.convertToAdminEntity(request);
         userRepository.save(user);
     }
 

--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/common/Constants.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/common/Constants.java
@@ -10,6 +10,7 @@ public class Constants {
     public static final String REFRESH_PATH = "/refreshToken";
     public static final String TEMPORARY_PATH = "/temporary";
     public static final String PAYMENTS_WS_PATH = "/payment";
+    public static final String ADMIN_PATH = "/admins";
 
     public static final String ROOT_USER_EMAIL = "admin@admin.pl";
     public static final String ROOT_USER_PASSWORD = "admin";

--- a/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/admin/converter/AdminConverterTest.java
+++ b/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/admin/converter/AdminConverterTest.java
@@ -1,0 +1,73 @@
+package pl.edu.pjatk.lnpayments.webservice.admin.converter;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import pl.edu.pjatk.lnpayments.webservice.admin.resource.dto.AdminRequest;
+import pl.edu.pjatk.lnpayments.webservice.admin.resource.dto.AdminResponse;
+import pl.edu.pjatk.lnpayments.webservice.common.entity.AdminUser;
+import pl.edu.pjatk.lnpayments.webservice.common.entity.Role;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AdminConverterTest {
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @InjectMocks
+    private AdminConverter adminConverter;
+
+    @Test
+    void shouldConvertToAdminRequest() {
+        when(passwordEncoder.encode(anyString())).thenReturn("encoded_pass");
+        AdminRequest request = new AdminRequest("test@test.pl", "test", "pass");
+
+        AdminUser user = adminConverter.convertToEntity(request);
+
+        assertThat(user.getEmail()).isEqualTo("test@test.pl");
+        assertThat(user.getPassword()).isEqualTo("encoded_pass");
+        assertThat(user.getFullName()).isEqualTo("test");
+        assertThat(user.getRole()).isEqualTo(Role.ROLE_ADMIN);
+        verify(passwordEncoder).encode(anyString());
+    }
+
+    @Test
+    void shouldConvertAdminToDto() {
+        AdminUser adminUser = AdminUser.adminBuilder()
+                .email("test@test.pl")
+                .fullName("test")
+                .build();
+
+        AdminResponse response = adminConverter.convertToDto(adminUser);
+
+        assertThat(response.getEmail()).isEqualTo("test@test.pl");
+        assertThat(response.getFullName()).isEqualTo("test");
+    }
+
+    @Test
+    void shouldMapAllAdminsToPageOfResponses() {
+        Page<AdminUser> payments = new PageImpl<>(List.of(
+                new AdminUser("test1@test.pl", "test1", "test1"),
+                new AdminUser("test2@test.pl", "test2", "test2"),
+                new AdminUser("test3@test.pl", "test3", "test3")
+        ));
+
+        Page<AdminResponse> result = adminConverter.convertAllToDto(payments);
+
+        assertThat(result).hasSize(3);
+        assertThat(result).extracting(AdminResponse::getFullName)
+                .containsExactlyInAnyOrder("test1", "test2", "test3");
+    }
+}

--- a/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/admin/resource/AdminResourceIntegrationTest.java
+++ b/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/admin/resource/AdminResourceIntegrationTest.java
@@ -1,0 +1,96 @@
+package pl.edu.pjatk.lnpayments.webservice.admin.resource;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import pl.edu.pjatk.lnpayments.webservice.admin.resource.dto.AdminRequest;
+import pl.edu.pjatk.lnpayments.webservice.auth.repository.AdminUserRepository;
+import pl.edu.pjatk.lnpayments.webservice.auth.repository.UserRepository;
+import pl.edu.pjatk.lnpayments.webservice.common.entity.AdminUser;
+import pl.edu.pjatk.lnpayments.webservice.common.entity.StandardUser;
+import pl.edu.pjatk.lnpayments.webservice.helper.config.BaseIntegrationTest;
+import pl.edu.pjatk.lnpayments.webservice.helper.config.IntegrationTestConfiguration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ActiveProfiles("test")
+@AutoConfigureMockMvc(addFilters = false)
+@SpringBootTest(classes = IntegrationTestConfiguration.class)
+class AdminResourceIntegrationTest extends BaseIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private AdminUserRepository adminUserRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @AfterEach
+    void tearDown() {
+        userRepository.deleteAll();
+    }
+
+    @Test
+    void shouldReturn201AndSaveAdmin() throws Exception {
+        AdminRequest request = new AdminRequest("test@test.pl", "test", "zaq1@WSX");
+        mockMvc.perform(post("/admins")
+                        .content(new ObjectMapper().writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isCreated());
+        assertThat(adminUserRepository.existsByEmail("test@test.pl")).isTrue();
+    }
+
+    @Test
+    void shouldReturn409WhenEmailIsTaken() throws Exception {
+        AdminRequest request = new AdminRequest("test@test.pl", "test", "zaq1@WSX");
+        AdminUser user = AdminUser.adminBuilder().email("test@test.pl").build();
+        adminUserRepository.save(user);
+        mockMvc.perform(post("/admins")
+                        .content(new ObjectMapper().writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    void shouldReturn400WhenInputIsInvalid() throws Exception {
+        AdminRequest request = new AdminRequest(null, null, "");
+        mockMvc.perform(post("/admins")
+                        .content(new ObjectMapper().writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void shouldReturn200AndSavedAdmins() throws Exception {
+        AdminUser firstAdmin = AdminUser.adminBuilder().email("test1@test.pl").build();
+        AdminUser secondAdmin = AdminUser.adminBuilder().email("test2@test.pl").build();
+        StandardUser standardUser = new StandardUser("dd@dd.pl", "standard", "zaq1@WSX");
+        userRepository.save(standardUser);
+        adminUserRepository.save(firstAdmin);
+        adminUserRepository.save(secondAdmin);
+        String jsonContent = getJsonResponse("integration/payment/response/admins-GET-valid.json");
+        mockMvc.perform(get("/admins"))
+                .andExpect(status().isOk())
+                .andExpect(content().json(jsonContent));
+    }
+
+    @Test
+    void shouldReturn200AndEmptyListWhenNoUsers() throws Exception {
+        String jsonContent = getJsonResponse("integration/payment/response/admins-GET-empty.json");
+        mockMvc.perform(get("/admins"))
+                .andExpect(status().isOk())
+                .andExpect(content().json(jsonContent));
+    }
+}

--- a/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/admin/resource/AdminResourceTest.java
+++ b/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/admin/resource/AdminResourceTest.java
@@ -1,0 +1,46 @@
+package pl.edu.pjatk.lnpayments.webservice.admin.resource;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import pl.edu.pjatk.lnpayments.webservice.admin.resource.dto.AdminRequest;
+import pl.edu.pjatk.lnpayments.webservice.admin.resource.dto.AdminResponse;
+import pl.edu.pjatk.lnpayments.webservice.admin.service.AdminService;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class AdminResourceTest {
+
+    @Mock
+    private AdminService adminService;
+
+    @InjectMocks
+    private AdminResource adminResource;
+
+    @Test
+    void shouldReturnCreatedWhenUserCreated() {
+        AdminRequest request = new AdminRequest("test@test.pl", "test", "test");
+
+        ResponseEntity<?> response = adminResource.addAdmin(request);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        verify(adminService).createAdmin(request);
+    }
+
+    @Test
+    void shouldReturnOkForAdminsRequest() {
+        ResponseEntity<Page<AdminResponse>> response = adminResource.getAdmins(Pageable.unpaged());
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        verify(adminService).findAllAdmins(Pageable.unpaged());
+    }
+
+}

--- a/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/admin/service/AdminServiceTest.java
+++ b/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/admin/service/AdminServiceTest.java
@@ -1,0 +1,81 @@
+package pl.edu.pjatk.lnpayments.webservice.admin.service;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import pl.edu.pjatk.lnpayments.webservice.admin.converter.AdminConverter;
+import pl.edu.pjatk.lnpayments.webservice.admin.resource.dto.AdminRequest;
+import pl.edu.pjatk.lnpayments.webservice.admin.resource.dto.AdminResponse;
+import pl.edu.pjatk.lnpayments.webservice.auth.repository.AdminUserRepository;
+import pl.edu.pjatk.lnpayments.webservice.common.entity.AdminUser;
+
+import javax.validation.ValidationException;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AdminServiceTest {
+
+    @Mock
+    private AdminConverter adminConverter;
+
+    @Mock
+    private AdminUserRepository adminUserRepository;
+
+    @InjectMocks
+    private AdminService adminService;
+
+    @Test
+    void shouldSaveAdminWhenEmailIsNotOccupied() {
+        AdminRequest request = new AdminRequest("test@test.pl", "test", "pass");
+        AdminUser expectedUser = new AdminUser("test@test.pl", "test", "pass");
+        when(adminConverter.convertToEntity(request)).thenReturn(expectedUser);
+        when(adminUserRepository.existsByEmail(anyString())).thenReturn(false);
+
+        adminService.createAdmin(request);
+
+        verify(adminConverter).convertToEntity(request);
+        verify(adminUserRepository).save(expectedUser);
+        verify(adminUserRepository).existsByEmail(request.getEmail());
+    }
+
+    @Test
+    void shouldThrowExceptionWhenUserExists() {
+        AdminRequest request = new AdminRequest("test@test.pl", "test", "pass");
+        when(adminUserRepository.existsByEmail(anyString())).thenReturn(true);
+
+        assertThatExceptionOfType(ValidationException.class)
+                .isThrownBy(() -> adminService.createAdmin(request))
+                .withMessage("User with mail test@test.pl exists!");
+        verify(adminConverter, never()).convertToEntity(request);
+        verify(adminUserRepository, never()).save(any());
+    }
+
+    @Test
+    void shouldReturnAllAdmins() {
+        AdminUser firstAdmin = new AdminUser("test1@test.pl", "test1", "pass");
+        AdminUser secondAdmin = new AdminUser("test2@test.pl", "test2", "pass");
+        AdminResponse convertedFirst = new AdminResponse("test1@test.pl", "test1");
+        AdminResponse convertedSecond = new AdminResponse("test2@test.pl", "test2");
+        PageImpl<AdminUser> adminEntities = new PageImpl<>(List.of(firstAdmin, secondAdmin));
+        PageImpl<AdminResponse> adminDtos = new PageImpl<>(List.of(convertedFirst, convertedSecond));
+        when(adminUserRepository.findAll(any(Pageable.class))).thenReturn(adminEntities);
+        when(adminConverter.convertAllToDto(adminEntities)).thenReturn(adminDtos);
+
+        Page<AdminResponse> response = adminService.findAllAdmins(PageRequest.ofSize(2));
+        assertThat(response).isEqualTo(adminDtos);
+        verify(adminConverter).convertAllToDto(adminEntities);
+        verify(adminUserRepository).findAll(any(Pageable.class));
+    }
+}

--- a/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/admin/startup/InitialAdminLoaderTest.java
+++ b/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/admin/startup/InitialAdminLoaderTest.java
@@ -1,4 +1,4 @@
-package pl.edu.pjatk.lnpayments.webservice.common.startup;
+package pl.edu.pjatk.lnpayments.webservice.admin.startup;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
@@ -13,8 +13,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.LoggerFactory;
-import pl.edu.pjatk.lnpayments.webservice.auth.resource.dto.AdminRequest;
-import pl.edu.pjatk.lnpayments.webservice.auth.service.UserService;
+import pl.edu.pjatk.lnpayments.webservice.admin.resource.dto.AdminRequest;
+import pl.edu.pjatk.lnpayments.webservice.admin.service.AdminService;
 
 import javax.validation.ValidationException;
 
@@ -26,13 +26,13 @@ import static pl.edu.pjatk.lnpayments.webservice.common.Constants.ROOT_USER_EMAI
 import static pl.edu.pjatk.lnpayments.webservice.common.Constants.ROOT_USER_PASSWORD;
 
 @ExtendWith(MockitoExtension.class)
-class InitialDataLoaderTest {
+class InitialAdminLoaderTest {
 
     @Mock
-    private UserService userService;
+    private AdminService adminService;
 
     @InjectMocks
-    private InitialDataLoader initialDataLoader;
+    private InitialAdminLoader initialAdminLoader;
 
     private ListAppender<ILoggingEvent> logAppender;
 
@@ -40,15 +40,15 @@ class InitialDataLoaderTest {
     void setUp() {
         logAppender = new ListAppender<>();
         logAppender.start();
-        ((Logger) LoggerFactory.getLogger(InitialDataLoader.class)).addAppender(logAppender);
+        ((Logger) LoggerFactory.getLogger(InitialAdminLoader.class)).addAppender(logAppender);
     }
 
     @Test
     void shouldInvokeServiceAndLogInfo() {
-        initialDataLoader.run(null);
+        initialAdminLoader.run(null);
 
         ArgumentCaptor<AdminRequest> captor = ArgumentCaptor.forClass(AdminRequest.class);
-        verify(userService).createAdmin(captor.capture());
+        verify(adminService).createAdmin(captor.capture());
         AdminRequest request = captor.getValue();
         assertThat(request.getEmail()).isEqualTo(ROOT_USER_EMAIL);
         assertThat(request.getPassword()).isEqualTo(ROOT_USER_PASSWORD);
@@ -59,11 +59,11 @@ class InitialDataLoaderTest {
 
     @Test
     void shouldLogWarningWhenUserAlreadyExists() {
-        doThrow(ValidationException.class).when(userService).createAdmin(any());
+        doThrow(ValidationException.class).when(adminService).createAdmin(any());
 
-        initialDataLoader.run(null);
+        initialAdminLoader.run(null);
 
-        verify(userService).createAdmin(any());
+        verify(adminService).createAdmin(any());
         assertThat(logAppender.list)
                 .extracting(ILoggingEvent::getMessage, ILoggingEvent::getLevel)
                 .contains(Tuple.tuple("Unable to create initial admin user: null", Level.WARN));

--- a/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/auth/converter/UserConverterTest.java
+++ b/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/auth/converter/UserConverterTest.java
@@ -7,10 +7,12 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import pl.edu.pjatk.lnpayments.webservice.auth.resource.dto.AdminRequest;
 import pl.edu.pjatk.lnpayments.webservice.auth.resource.dto.LoginResponse;
 import pl.edu.pjatk.lnpayments.webservice.auth.resource.dto.RegisterRequest;
-import pl.edu.pjatk.lnpayments.webservice.common.entity.*;
+import pl.edu.pjatk.lnpayments.webservice.common.entity.Role;
+import pl.edu.pjatk.lnpayments.webservice.common.entity.StandardUser;
+import pl.edu.pjatk.lnpayments.webservice.common.entity.TemporaryUser;
+import pl.edu.pjatk.lnpayments.webservice.common.entity.User;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -76,17 +78,4 @@ class UserConverterTest {
         assertThat(userDetails.getAuthorities().contains(Role.ROLE_TEMPORARY)).isTrue();
     }
 
-    @Test
-    void shouldConvertToAdminRequest() {
-        when(passwordEncoder.encode(anyString())).thenReturn("encoded_pass");
-        AdminRequest request = new AdminRequest("test@test.pl", "test", "pass");
-
-        AdminUser user = userConverter.convertToAdminEntity(request);
-
-        assertThat(user.getEmail()).isEqualTo("test@test.pl");
-        assertThat(user.getPassword()).isEqualTo("encoded_pass");
-        assertThat(user.getFullName()).isEqualTo("test");
-        assertThat(user.getRole()).isEqualTo(Role.ROLE_ADMIN);
-        verify(passwordEncoder).encode(anyString());
-    }
 }

--- a/webservice/src/test/resources/integration/payment/response/admins-GET-empty.json
+++ b/webservice/src/test/resources/integration/payment/response/admins-GET-empty.json
@@ -1,0 +1,28 @@
+{
+  "content": [],
+  "pageable": {
+    "sort": {
+      "empty": true,
+      "sorted": false,
+      "unsorted": true
+    },
+    "pageNumber": 0,
+    "pageSize": 20,
+    "offset": 0,
+    "paged": true,
+    "unpaged": false
+  },
+  "last": true,
+  "totalPages": 0,
+  "totalElements": 0,
+  "first": true,
+  "size": 20,
+  "number": 0,
+  "sort": {
+    "empty": true,
+    "sorted": false,
+    "unsorted": true
+  },
+  "numberOfElements": 0,
+  "empty": true
+}

--- a/webservice/src/test/resources/integration/payment/response/admins-GET-valid.json
+++ b/webservice/src/test/resources/integration/payment/response/admins-GET-valid.json
@@ -1,0 +1,37 @@
+{
+  "content": [
+    {
+      "fullName": null,
+      "email": "test1@test.pl"
+    },
+    {
+      "fullName": null,
+      "email": "test2@test.pl"
+    }
+  ],
+  "pageable": {
+    "sort": {
+      "empty": true,
+      "sorted": false,
+      "unsorted": true
+    },
+    "pageNumber": 0,
+    "pageSize": 20,
+    "offset": 0,
+    "paged": true,
+    "unpaged": false
+  },
+  "last": true,
+  "totalPages": 1,
+  "totalElements": 2,
+  "first": true,
+  "size": 20,
+  "number": 0,
+  "sort": {
+    "empty": true,
+    "sorted": false,
+    "unsorted": true
+  },
+  "numberOfElements": 2,
+  "empty": false
+}


### PR DESCRIPTION
Link to the Jira issue
https://candybear.atlassian.net/browse/LP-90

### Description

Added POST /admins and GET /admins to add and query admins. Endpoint is accessible only for those, who have admin role.

### How did I test it

Manually, unit and integration tests