### PR TITLE
LP-105 Add endpoint for querying all payments

### DIFF
--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/auth/config/WebSecurityConfig.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/auth/config/WebSecurityConfig.java
@@ -37,7 +37,8 @@ class WebSecurityConfig extends WebSecurityConfigurerAdapter {
     };
 
     private final static String[] ADMIN_PATHS = {
-            AUTH_PATH + ADMIN_PATH
+            AUTH_PATH + ADMIN_PATH,
+            PAYMENTS_PATH + ALL_PATH
     };
 
     private final UserDetailsService userDetailsService;

--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/common/Constants.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/common/Constants.java
@@ -5,6 +5,7 @@ public class Constants {
     public static final String PAYMENTS_PATH = "/payments";
     public static final String AUTH_PATH = "/auth";
     public static final String INFO_PATH = "/info";
+    public static final String ALL_PATH = "/all";
     public static final String REGISTER_PATH = "/register";
     public static final String LOGIN_PATH = "/login";
     public static final String REFRESH_PATH = "/refreshToken";

--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/payment/facade/PaymentFacade.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/payment/facade/PaymentFacade.java
@@ -106,4 +106,8 @@ public class PaymentFacade {
     public Page<Payment> getPaymentsByEmail(String email, Pageable pageable) {
         return paymentDataService.findAll(SearchableField.EMAIL, email, pageable);
     }
+
+    public Page<Payment> getAllPayments(Pageable pageable) {
+        return paymentDataService.findAll(pageable);
+    }
 }

--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/payment/repository/PaymentRepository.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/payment/repository/PaymentRepository.java
@@ -1,7 +1,7 @@
 package pl.edu.pjatk.lnpayments.webservice.payment.repository;
 
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
-import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 import pl.edu.pjatk.lnpayments.webservice.payment.model.entity.Payment;
 import pl.edu.pjatk.lnpayments.webservice.payment.model.entity.PaymentStatus;
@@ -10,7 +10,7 @@ import java.util.Collection;
 import java.util.Optional;
 
 @Repository
-public interface PaymentRepository extends CrudRepository<Payment, Long>, JpaSpecificationExecutor<Payment> {
+public interface PaymentRepository extends JpaRepository<Payment, Long>, JpaSpecificationExecutor<Payment> {
 
     Optional<Payment> findPaymentByPaymentRequest(String paymentRequest);
 

--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/payment/resource/PaymentResource.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/payment/resource/PaymentResource.java
@@ -10,6 +10,7 @@ import pl.edu.pjatk.lnpayments.webservice.payment.model.PaymentInfo;
 import pl.edu.pjatk.lnpayments.webservice.payment.model.entity.Payment;
 import pl.edu.pjatk.lnpayments.webservice.payment.resource.converter.PaymentDetailsConverter;
 import pl.edu.pjatk.lnpayments.webservice.payment.resource.converter.PaymentInfoConverter;
+import pl.edu.pjatk.lnpayments.webservice.payment.resource.dto.PaymentAdminDetailsResponse;
 import pl.edu.pjatk.lnpayments.webservice.payment.resource.dto.PaymentDetailsRequest;
 import pl.edu.pjatk.lnpayments.webservice.payment.resource.dto.PaymentDetailsResponse;
 import pl.edu.pjatk.lnpayments.webservice.payment.resource.dto.PaymentInfoResponse;
@@ -18,8 +19,7 @@ import javax.validation.Valid;
 import java.security.Principal;
 import java.util.Optional;
 
-import static pl.edu.pjatk.lnpayments.webservice.common.Constants.INFO_PATH;
-import static pl.edu.pjatk.lnpayments.webservice.common.Constants.PAYMENTS_PATH;
+import static pl.edu.pjatk.lnpayments.webservice.common.Constants.*;
 
 @RestController
 @RequestMapping(PAYMENTS_PATH)
@@ -55,9 +55,15 @@ public class PaymentResource {
     }
 
     @GetMapping
-    public ResponseEntity<Page<?>> getAllUserPayments(Principal principal, Pageable pageable) {
+    public ResponseEntity<Page<PaymentDetailsResponse>> getAllUserPayments(Principal principal, Pageable pageable) {
         Page<Payment> payments = paymentFacade.getPaymentsByEmail(principal.getName(), pageable);
         return ResponseEntity.ok(paymentDetailsConverter.convertPageToDto(payments));
+    }
+
+    @GetMapping(ALL_PATH)
+    public ResponseEntity<Page<PaymentAdminDetailsResponse>> getAllPayments(Pageable pageable) {
+        Page<Payment> payments = paymentFacade.getAllPayments(pageable);
+        return ResponseEntity.ok(paymentDetailsConverter.convertPageToAdminDto(payments));
     }
 
 }

--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/payment/resource/converter/PaymentDetailsConverter.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/payment/resource/converter/PaymentDetailsConverter.java
@@ -5,6 +5,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import pl.edu.pjatk.lnpayments.webservice.payment.model.entity.Payment;
 import pl.edu.pjatk.lnpayments.webservice.payment.model.entity.Token;
+import pl.edu.pjatk.lnpayments.webservice.payment.resource.dto.PaymentAdminDetailsResponse;
 import pl.edu.pjatk.lnpayments.webservice.payment.resource.dto.PaymentDetailsResponse;
 
 import java.util.List;
@@ -32,7 +33,21 @@ public class PaymentDetailsConverter {
         return payment.getTokens().stream().map(Token::getSequence).collect(Collectors.toList());
     }
 
+    public PaymentAdminDetailsResponse convertToAdminDto(Payment payment) {
+        return PaymentAdminDetailsResponse.builder()
+                .email(payment.getUser().getEmail())
+                .numberOfTokens(payment.getNumberOfTokens())
+                .price(payment.getPrice())
+                .timestamp(payment.getDate())
+                .paymentStatus(payment.getStatus())
+                .build();
+    }
+
     public Page<PaymentDetailsResponse> convertPageToDto(Page<Payment> payments) {
         return payments.map(this::convertToDto);
+    }
+
+    public Page<PaymentAdminDetailsResponse> convertPageToAdminDto(Page<Payment> payments) {
+        return payments.map(this::convertToAdminDto);
     }
 }

--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/payment/resource/dto/PaymentAdminDetailsResponse.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/payment/resource/dto/PaymentAdminDetailsResponse.java
@@ -1,0 +1,19 @@
+package pl.edu.pjatk.lnpayments.webservice.payment.resource.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import pl.edu.pjatk.lnpayments.webservice.payment.model.entity.PaymentStatus;
+
+import java.time.Instant;
+
+@Getter
+@Builder
+public class PaymentAdminDetailsResponse {
+
+    private String email;
+    private Instant timestamp;
+    private int price;
+    private int numberOfTokens;
+    private PaymentStatus paymentStatus;
+
+}

--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/payment/service/PaymentDataService.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/payment/service/PaymentDataService.java
@@ -39,4 +39,8 @@ public class PaymentDataService {
     public Page<Payment> findAll(SearchableField field, String value, Pageable pageable) {
         return paymentRepository.findAll(new PaymentSpecification(field, value), pageable);
     }
+
+    public Page<Payment> findAll(Pageable pageable) {
+        return paymentRepository.findAll(pageable);
+    }
 }

--- a/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/helper/factory/UserFactory.java
+++ b/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/helper/factory/UserFactory.java
@@ -1,5 +1,6 @@
 package pl.edu.pjatk.lnpayments.webservice.helper.factory;
 
+import pl.edu.pjatk.lnpayments.webservice.common.entity.AdminUser;
 import pl.edu.pjatk.lnpayments.webservice.common.entity.Role;
 import pl.edu.pjatk.lnpayments.webservice.common.entity.StandardUser;
 import pl.edu.pjatk.lnpayments.webservice.common.entity.User;
@@ -20,5 +21,9 @@ public class UserFactory {
 
     public static User createStandardUser(String email) {
         return new StandardUser(email, "asd", "asd");
+    }
+
+    public static User createAdminUser(String email) {
+        return new AdminUser(email, "asd", "asd");
     }
 }

--- a/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/payment/facade/PaymentFacadeTest.java
+++ b/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/payment/facade/PaymentFacadeTest.java
@@ -143,4 +143,19 @@ class PaymentFacadeTest {
         assertThat(response).hasSize(3);
         verify(paymentDataService).findAll(any(), anyString(), any());
     }
+
+    @Test
+    void shouldReturnAllPayments() {
+        Page<Payment> payments = new PageImpl<>(List.of(
+                new Payment("123", 1, 1, 123, PaymentStatus.PENDING, null),
+                new Payment("456", 3, 2, 126, PaymentStatus.COMPLETE, null),
+                new Payment("789", 4, 3, 129, PaymentStatus.CANCELLED, null)
+        ));
+        when(paymentDataService.findAll(null)).thenReturn(payments);
+
+        Page<Payment> response = paymentFacade.getAllPayments(null);
+        assertThat(response).hasSize(3);
+        verify(paymentDataService).findAll(any());
+    }
+
 }

--- a/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/payment/resource/PaymentResourceTest.java
+++ b/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/payment/resource/PaymentResourceTest.java
@@ -72,4 +72,14 @@ class PaymentResourceTest {
             assertThat(payments.getStatusCode()).isEqualTo(HttpStatus.OK);
         }
     }
+
+    @Nested
+    class AllPaymentsTest {
+        @Test
+        void shouldReturnOkForValidRequest() {
+            ResponseEntity<?> payments = paymentResource.getAllPayments(null);
+
+            assertThat(payments.getStatusCode()).isEqualTo(HttpStatus.OK);
+        }
+    }
 }

--- a/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/payment/resource/converter/PaymentDetailsConverterTest.java
+++ b/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/payment/resource/converter/PaymentDetailsConverterTest.java
@@ -3,13 +3,17 @@ package pl.edu.pjatk.lnpayments.webservice.payment.resource.converter;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
+import pl.edu.pjatk.lnpayments.webservice.common.entity.User;
 import pl.edu.pjatk.lnpayments.webservice.payment.model.entity.Payment;
 import pl.edu.pjatk.lnpayments.webservice.payment.model.entity.PaymentStatus;
+import pl.edu.pjatk.lnpayments.webservice.payment.resource.dto.PaymentAdminDetailsResponse;
 import pl.edu.pjatk.lnpayments.webservice.payment.resource.dto.PaymentDetailsResponse;
 
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static pl.edu.pjatk.lnpayments.webservice.helper.factory.UserFactory.createAdminUser;
+import static pl.edu.pjatk.lnpayments.webservice.helper.factory.UserFactory.createStandardUser;
 
 class PaymentDetailsConverterTest {
 
@@ -42,6 +46,38 @@ class PaymentDetailsConverterTest {
         assertThat(result).hasSize(3);
         assertThat(result).extracting(PaymentDetailsResponse::getPaymentRequest)
                 .containsExactlyInAnyOrder("123", "456", "789");
+    }
+
+    @Test
+    void shouldConvertToAdminDto() {
+        Payment payment = new Payment("123",
+                1,
+                1,
+                123,
+                PaymentStatus.PENDING,
+                createAdminUser("test@test.pl"));
+
+        PaymentAdminDetailsResponse response = paymentDetailsConverter.convertToAdminDto(payment);
+
+        assertThat(response.getEmail()).isEqualTo("test@test.pl");
+        assertThat(response.getNumberOfTokens()).isEqualTo(1);
+        assertThat(response.getPrice()).isEqualTo(1);
+        assertThat(response.getPaymentStatus()).isEqualTo(PaymentStatus.PENDING);
+        assertThat(response.getTimestamp()).isEqualTo(payment.getDate());
+    }
+
+    @Test
+    void shouldConvertPageToAdminDto() {
+        User user = createStandardUser("test@test.pl");
+        Page<Payment> payments = new PageImpl<>(List.of(
+                new Payment("123", 1, 1, 123, PaymentStatus.PENDING, user),
+                new Payment("456", 3, 2, 126, PaymentStatus.COMPLETE, user),
+                new Payment("789", 4, 3, 129, PaymentStatus.CANCELLED, user)
+        ));
+
+        Page<PaymentAdminDetailsResponse> result = paymentDetailsConverter.convertPageToAdminDto(payments);
+
+        assertThat(result).hasSize(3);
     }
 
 }

--- a/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/payment/service/PaymentDataServiceTest.java
+++ b/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/payment/service/PaymentDataServiceTest.java
@@ -26,10 +26,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
-/**
- * Tests here are a little dump at the moment. This will probably change in the future as we add more functionalities
- * there. We must keep them for now for sake of code coverage.
- */
 @ExtendWith(MockitoExtension.class)
 class PaymentDataServiceTest {
 
@@ -95,6 +91,29 @@ class PaymentDataServiceTest {
                 .thenReturn(new PageImpl<>(List.of()));
 
         Page<Payment> response = paymentDataService.findAll(SearchableField.EMAIL, "test", PageRequest.ofSize(3));
+
+        assertThat(response).isEmpty();
+    }
+
+    @Test
+    void shouldReturnAllPayments() {
+        List<Payment> payments = List.of(
+                new Payment("123", 1, 1, 123, PaymentStatus.PENDING, null),
+                new Payment("456", 3, 2, 126, PaymentStatus.COMPLETE, null),
+                new Payment("789", 4, 3, 129, PaymentStatus.CANCELLED, null)
+        );
+        when(paymentRepository.findAll(any(Pageable.class))).thenReturn(new PageImpl<>(payments));
+
+        Page<Payment> response = paymentDataService.findAll(PageRequest.ofSize(3));
+
+        assertThat(response).hasSize(3);
+    }
+
+    @Test
+    void shouldReturnEmptyArrayWhenNoPayments() {
+        when(paymentRepository.findAll(any(Pageable.class))).thenReturn(new PageImpl<>(List.of()));
+
+        Page<Payment> response = paymentDataService.findAll(PageRequest.ofSize(3));
 
         assertThat(response).isEmpty();
     }

--- a/webservice/src/test/resources/integration/payment/response/payments-all-GET-valid.json
+++ b/webservice/src/test/resources/integration/payment/response/payments-all-GET-valid.json
@@ -1,0 +1,59 @@
+{
+  "content": [
+    {
+      "email": "admin@admin.pl",
+      "price": 1,
+      "numberOfTokens": 1,
+      "paymentStatus": "PENDING"
+    },
+    {
+      "email": "admin@admin.pl",
+      "price": 2,
+      "numberOfTokens": 3,
+      "paymentStatus": "COMPLETE"
+    },
+    {
+      "email": "admin@admin.pl",
+      "price": 3,
+      "numberOfTokens": 4,
+      "paymentStatus": "CANCELLED"
+    },
+    {
+      "email": "test@test.pl",
+      "price": 3,
+      "numberOfTokens": 4,
+      "paymentStatus": "CANCELLED"
+    },
+    {
+      "email": "test@test.pl",
+      "price": 3,
+      "numberOfTokens": 4,
+      "paymentStatus": "CANCELLED"
+    }
+  ],
+  "pageable": {
+    "sort": {
+      "sorted": false,
+      "unsorted": true,
+      "empty": true
+    },
+    "pageNumber": 0,
+    "pageSize": 20,
+    "offset": 0,
+    "paged": true,
+    "unpaged": false
+  },
+  "last": true,
+  "totalPages": 1,
+  "totalElements": 5,
+  "sort": {
+    "sorted": false,
+    "unsorted": true,
+    "empty": true
+  },
+  "number": 0,
+  "first": true,
+  "numberOfElements": 5,
+  "size": 20,
+  "empty": false
+}


### PR DESCRIPTION
Link to the Jira issue
https://candybear.atlassian.net/browse/LP-105

### Description

Endpoint to find all payments by admin has been added. Accessible only when user has admin role. Fields:
```json
  {
            "email": "test@wp.pl",
            "timestamp": "2022-03-21T17:08:32.557087Z",
            "price": 100,
            "numberOfTokens": 1,
            "paymentStatus": "CANCELLED"
  }
```

### How did I test it

Manually, unit and integration tests.
