### PR TITLE
LP-97 Create wallet creation endpoint

### DIFF
--- a/docs/diagrams/create_wallet_flow.puml
+++ b/docs/diagrams/create_wallet_flow.puml
@@ -1,0 +1,13 @@
+@startuml
+start
+:Request to create wallet with admin emails and required confirmations;
+if (there is a running wallet || received more numOfConfirmations than users) then (true)
+    :throw exception;
+endif
+:query for admins;
+:verify if all of them have keys;
+:create wallet(scripts, address);
+:save wallet to DB;
+:return Http 201;
+end
+@enduml

--- a/webservice/pom.xml
+++ b/webservice/pom.xml
@@ -25,6 +25,7 @@
         <jjwt.version>0.9.1</jjwt.version>
         <springfox-swagger.version>3.0.0</springfox-swagger.version>
         <hibernate-jpamodelgen.version>5.6.5.Final</hibernate-jpamodelgen.version>
+        <bitcoinj-core.version>0.16.1</bitcoinj-core.version>
     </properties>
 
     <dependencies>
@@ -120,6 +121,11 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-devtools</artifactId>
             <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.bitcoinj</groupId>
+            <artifactId>bitcoinj-core</artifactId>
+            <version>${bitcoinj-core.version}</version>
         </dependency>
     </dependencies>
 

--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/admin/service/AdminService.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/admin/service/AdminService.java
@@ -9,9 +9,11 @@ import pl.edu.pjatk.lnpayments.webservice.admin.resource.dto.AdminRequest;
 import pl.edu.pjatk.lnpayments.webservice.admin.resource.dto.AdminResponse;
 import pl.edu.pjatk.lnpayments.webservice.auth.repository.AdminUserRepository;
 import pl.edu.pjatk.lnpayments.webservice.common.entity.AdminUser;
+import pl.edu.pjatk.lnpayments.webservice.common.exception.InconsistentDataException;
 
 import javax.transaction.Transactional;
 import javax.validation.ValidationException;
+import java.util.List;
 
 @Service
 public class AdminService {
@@ -38,5 +40,13 @@ public class AdminService {
     public Page<AdminResponse> findAllAdmins(Pageable pageable) {
         Page<AdminUser> admins = adminUserRepository.findAll(pageable);
         return adminConverter.convertAllToDto(admins);
+    }
+
+    public List<AdminUser> findAllWithKeys(List<String> emails) {
+        List<AdminUser> adminUsers = adminUserRepository.findAllByEmailInAndPublicKeyNotNull(emails);
+        if (adminUsers.size() != emails.size()) {
+            throw new InconsistentDataException("Not all users have uploaded their keys");
+        }
+        return adminUsers;
     }
 }

--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/auth/config/WebSecurityConfig.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/auth/config/WebSecurityConfig.java
@@ -38,7 +38,8 @@ class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 
     private final static String[] ADMIN_PATHS = {
             AUTH_PATH + ADMIN_PATH,
-            PAYMENTS_PATH + ALL_PATH
+            PAYMENTS_PATH + ALL_PATH,
+            WALLET_PATH
     };
 
     private final UserDetailsService userDetailsService;

--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/auth/repository/AdminUserRepository.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/auth/repository/AdminUserRepository.java
@@ -3,7 +3,11 @@ package pl.edu.pjatk.lnpayments.webservice.auth.repository;
 import org.springframework.stereotype.Repository;
 import pl.edu.pjatk.lnpayments.webservice.common.entity.AdminUser;
 
+import java.util.List;
+
 @Repository
 public interface AdminUserRepository extends BaseUserRepository<AdminUser> {
+
+    List<AdminUser> findAllByEmailInAndPublicKeyNotNull(List<String> emails);
 
 }

--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/common/Constants.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/common/Constants.java
@@ -12,6 +12,7 @@ public class Constants {
     public static final String TEMPORARY_PATH = "/temporary";
     public static final String PAYMENTS_WS_PATH = "/payment";
     public static final String ADMIN_PATH = "/admins";
+    public static final String WALLET_PATH = "/wallet";
 
     public static final String ROOT_USER_EMAIL = "admin@admin.pl";
     public static final String ROOT_USER_PASSWORD = "admin";

--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/common/entity/AdminUser.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/common/entity/AdminUser.java
@@ -18,6 +18,9 @@ public class AdminUser extends StandardUser {
         super(email, fullName, password);
     }
 
+    //TODO replace with real one, when implementing endpoint for uploading keys
+    private String publicKey = "0346b221a71369a6f70be9660ae560096396cf6813a051fcaf50a418d517007fcb";
+
     @Override
     public Role getRole() {
         return Role.ROLE_ADMIN;

--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/common/exception/GlobalExceptionHandler.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/common/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package pl.edu.pjatk.lnpayments.webservice.common.exception;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -8,12 +9,19 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
 
 import javax.validation.ValidationException;
 
+@Slf4j
 @ControllerAdvice
 class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     @ResponseStatus(HttpStatus.CONFLICT)
     @ExceptionHandler(ValidationException.class)
-    void handleValidationException() {
+    void handleConflicts() {
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(InconsistentDataException.class)
+    void handleInconsistentDataException(Exception exception) {
+        logger.error(exception);
     }
 
 }

--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/common/exception/InconsistentDataException.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/common/exception/InconsistentDataException.java
@@ -1,0 +1,11 @@
+package pl.edu.pjatk.lnpayments.webservice.common.exception;
+
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+public class InconsistentDataException extends RuntimeException {
+
+    public InconsistentDataException(String message) {
+        super(message);
+    }
+}

--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/payment/exception/InconsistentDataException.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/payment/exception/InconsistentDataException.java
@@ -1,4 +1,0 @@
-package pl.edu.pjatk.lnpayments.webservice.payment.exception;
-
-public class InconsistentDataException extends RuntimeException {
-}

--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/payment/service/PaymentDataService.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/payment/service/PaymentDataService.java
@@ -4,7 +4,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
-import pl.edu.pjatk.lnpayments.webservice.payment.exception.InconsistentDataException;
+import pl.edu.pjatk.lnpayments.webservice.common.exception.InconsistentDataException;
 import pl.edu.pjatk.lnpayments.webservice.payment.model.entity.Payment;
 import pl.edu.pjatk.lnpayments.webservice.payment.model.entity.PaymentStatus;
 import pl.edu.pjatk.lnpayments.webservice.payment.repository.PaymentRepository;

--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/wallet/config/Network.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/wallet/config/Network.java
@@ -1,0 +1,24 @@
+package pl.edu.pjatk.lnpayments.webservice.wallet.config;
+
+import org.bitcoinj.core.NetworkParameters;
+import org.bitcoinj.params.MainNetParams;
+import org.bitcoinj.params.RegTestParams;
+import org.bitcoinj.params.TestNet3Params;
+
+enum Network {
+
+    MAINNET(MainNetParams.get()),
+    TESTNET(TestNet3Params.get()),
+    REGTEST(RegTestParams.get());
+
+    private final NetworkParameters parameters;
+
+    Network(NetworkParameters parameters) {
+        this.parameters = parameters;
+    }
+
+    NetworkParameters getParameters() {
+        return parameters;
+    }
+
+}

--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/wallet/config/WalletConfig.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/wallet/config/WalletConfig.java
@@ -1,0 +1,33 @@
+package pl.edu.pjatk.lnpayments.webservice.wallet.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.bitcoinj.kits.WalletAppKit;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.io.File;
+
+@Slf4j
+@Configuration
+class WalletConfig {
+
+    @Value("${lnp.wallet.network}")
+    private String network;
+
+    @Value("${lnp.config.workingDirectory}")
+    private String walletDirectory;
+
+    @Value("${lnp.wallet.fileName}")
+    private String fileName;
+
+    @Bean
+    WalletAppKit walletAppKit() {
+        WalletAppKit walletAppKit = new WalletAppKit(
+                Network.valueOf(network.toUpperCase()).getParameters(), new File(walletDirectory), fileName);
+        walletAppKit.startAsync();
+        walletAppKit.awaitRunning();
+        log.info("Bitcoin wallet started!");
+        return walletAppKit;
+    }
+}

--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/wallet/entity/Wallet.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/wallet/entity/Wallet.java
@@ -1,0 +1,43 @@
+package pl.edu.pjatk.lnpayments.webservice.wallet.entity;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import pl.edu.pjatk.lnpayments.webservice.common.entity.AdminUser;
+
+import javax.persistence.*;
+import java.util.List;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+public class Wallet {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String redeemScript;
+
+    private String scriptPubKey;
+
+    private String address;
+
+    @Enumerated(EnumType.STRING)
+    private WalletStatus status;
+
+    @OneToMany(fetch = FetchType.EAGER)
+    @JoinColumn(name = "wallet_id")
+    private List<AdminUser> users;
+
+    @Builder
+    public Wallet(String redeemScript, String scriptPubKey, String address, List<AdminUser> users) {
+        this.redeemScript = redeemScript;
+        this.scriptPubKey = scriptPubKey;
+        this.address = address;
+        this.users = users;
+        this.status = WalletStatus.ON_DUTY;
+    }
+}

--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/wallet/entity/WalletStatus.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/wallet/entity/WalletStatus.java
@@ -1,0 +1,6 @@
+package pl.edu.pjatk.lnpayments.webservice.wallet.entity;
+
+public enum WalletStatus {
+    REMOVED,
+    ON_DUTY
+}

--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/wallet/repository/WalletRepository.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/wallet/repository/WalletRepository.java
@@ -1,0 +1,12 @@
+package pl.edu.pjatk.lnpayments.webservice.wallet.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import pl.edu.pjatk.lnpayments.webservice.wallet.entity.Wallet;
+import pl.edu.pjatk.lnpayments.webservice.wallet.entity.WalletStatus;
+
+@Repository
+public interface WalletRepository extends JpaRepository<Wallet, Long> {
+
+    boolean existsByStatus(WalletStatus status);
+}

--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/wallet/resource/WalletResource.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/wallet/resource/WalletResource.java
@@ -1,0 +1,31 @@
+package pl.edu.pjatk.lnpayments.webservice.wallet.resource;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import pl.edu.pjatk.lnpayments.webservice.wallet.resource.dto.CreateWalletRequest;
+import pl.edu.pjatk.lnpayments.webservice.wallet.service.WalletService;
+
+import javax.validation.Valid;
+
+import static pl.edu.pjatk.lnpayments.webservice.common.Constants.WALLET_PATH;
+
+@RestController
+@RequestMapping(WALLET_PATH)
+class WalletResource {
+
+    private final WalletService walletService;
+
+    @Autowired
+    public WalletResource(WalletService walletService) {
+        this.walletService = walletService;
+    }
+
+    @PostMapping
+    ResponseEntity<?> createWallet(@Valid @RequestBody CreateWalletRequest createWalletRequest) {
+        walletService.createWallet(createWalletRequest.getAdminEmails(), createWalletRequest.getMinSignatures());
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+}

--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/wallet/resource/dto/CreateWalletRequest.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/wallet/resource/dto/CreateWalletRequest.java
@@ -1,0 +1,23 @@
+package pl.edu.pjatk.lnpayments.webservice.wallet.resource.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.Size;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateWalletRequest {
+
+    @Min(1)
+    @Max(10)
+    private int minSignatures;
+    @Size(min = 1)
+    private List<@Email String> adminEmails;
+}

--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/wallet/service/BitcoinService.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/wallet/service/BitcoinService.java
@@ -1,0 +1,47 @@
+package pl.edu.pjatk.lnpayments.webservice.wallet.service;
+
+import org.bitcoinj.core.Address;
+import org.bitcoinj.core.ECKey;
+import org.bitcoinj.kits.WalletAppKit;
+import org.bitcoinj.script.Script;
+import org.bitcoinj.script.ScriptBuilder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import pl.edu.pjatk.lnpayments.webservice.common.entity.AdminUser;
+import pl.edu.pjatk.lnpayments.webservice.wallet.entity.Wallet;
+
+import java.util.HexFormat;
+import java.util.List;
+
+@Service
+public class BitcoinService {
+
+    private final WalletAppKit walletAppKit;
+
+    @Autowired
+    public BitcoinService(WalletAppKit walletAppKit) {
+        this.walletAppKit = walletAppKit;
+    }
+
+    public Wallet createWallet(List<AdminUser> admins, int minNumberOfConfirmations) {
+        List<ECKey> keys = mapToKeys(admins);
+        Script redeemScript = ScriptBuilder.createRedeemScript(minNumberOfConfirmations, keys);
+        Script scriptPubKey = ScriptBuilder.createP2SHOutputScript(redeemScript);
+        Address address = scriptPubKey.getToAddress(walletAppKit.params());
+        walletAppKit.wallet().addWatchedAddress(address);
+        return Wallet.builder()
+                .address(address.toString())
+                .redeemScript(HexFormat.of().formatHex(redeemScript.getProgram()))
+                .scriptPubKey(HexFormat.of().formatHex(scriptPubKey.getProgram()))
+                .users(admins)
+                .build();
+    }
+
+    private List<ECKey> mapToKeys(List<AdminUser> admins) {
+        return admins.stream()
+                .map(AdminUser::getPublicKey)
+                .map(e -> ECKey.fromPublicOnly(HexFormat.of().parseHex(e)))
+                .sorted(ECKey.PUBKEY_COMPARATOR)
+                .toList();
+    }
+}

--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/wallet/service/WalletService.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/wallet/service/WalletService.java
@@ -1,0 +1,41 @@
+package pl.edu.pjatk.lnpayments.webservice.wallet.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import pl.edu.pjatk.lnpayments.webservice.admin.service.AdminService;
+import pl.edu.pjatk.lnpayments.webservice.common.entity.AdminUser;
+import pl.edu.pjatk.lnpayments.webservice.common.exception.InconsistentDataException;
+import pl.edu.pjatk.lnpayments.webservice.wallet.entity.Wallet;
+import pl.edu.pjatk.lnpayments.webservice.wallet.entity.WalletStatus;
+import pl.edu.pjatk.lnpayments.webservice.wallet.repository.WalletRepository;
+
+import javax.validation.ValidationException;
+import java.util.List;
+
+@Service
+public class WalletService {
+
+    private final BitcoinService bitcoinService;
+    private final AdminService adminService;
+    private final WalletRepository walletRepository;
+
+    @Autowired
+    public WalletService(BitcoinService bitcoinService, AdminService adminService, WalletRepository walletRepository) {
+        this.bitcoinService = bitcoinService;
+        this.adminService = adminService;
+        this.walletRepository = walletRepository;
+    }
+
+    public void createWallet(List<String> adminEmails, int minSignatures) {
+        if (walletRepository.existsByStatus(WalletStatus.ON_DUTY)) {
+            throw new ValidationException("Wallet already exists!");
+        }
+        if (adminEmails.size() < minSignatures) {
+            throw new InconsistentDataException("You can't require more confirmations than you have users");
+        }
+        List<AdminUser> adminUsers = adminService.findAllWithKeys(adminEmails);
+        Wallet wallet = bitcoinService.createWallet(adminUsers, minSignatures);
+        walletRepository.save(wallet);
+    }
+
+}

--- a/webservice/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/webservice/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -34,6 +34,21 @@
       "name": "lnp.auth.jwtSecret",
       "type": "java.lang.String",
       "description": "Description for lnp.auth.jwtSecret."
+    },
+    {
+      "name": "lnp.wallet.fileName",
+      "type": "java.lang.String",
+      "description": "Description for lnp.wallet.fileName."
+    },
+    {
+      "name": "lnp.config.workingDirectory",
+      "type": "java.lang.String",
+      "description": "Description for lnp.config.workingDirectory."
+    },
+    {
+      "name": "lnp.wallet.network",
+      "type": "pl.edu.pjatk.lnpayments.webservice.wallet.config.Network",
+      "description": "Description for lnp.wallet.network."
     }
   ]
 }

--- a/webservice/src/main/resources/application.properties
+++ b/webservice/src/main/resources/application.properties
@@ -20,3 +20,8 @@ lnp.misc.ipRetrieverUrl=https://checkip.amazonaws.com/
 
 lnp.auth.expirationInMs=3600000
 lnp.auth.jwtSecret=L))::Z.&I!!vA_X.aR<*DScss&xfe.9d[I}{AnyQ+[#ik=W_4_y<?'uVtC@Jeg'j
+
+lnp.wallet.fileName=lnp
+lnp.wallet.network=testnet
+
+lnp.config.workingDirectory=~/.

--- a/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/helper/config/IntegrationTestConfiguration.java
+++ b/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/helper/config/IntegrationTestConfiguration.java
@@ -1,5 +1,8 @@
 package pl.edu.pjatk.lnpayments.webservice.helper.config;
 
+import org.bitcoinj.kits.WalletAppKit;
+import org.bitcoinj.params.RegTestParams;
+import org.bitcoinj.wallet.Wallet;
 import org.lightningj.lnd.wrapper.AsynchronousAPI;
 import org.lightningj.lnd.wrapper.StatusException;
 import org.lightningj.lnd.wrapper.SynchronousLndAPI;
@@ -11,6 +14,7 @@ import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @TestConfiguration
@@ -31,6 +35,14 @@ public class IntegrationTestConfiguration {
     @Bean
     AsynchronousAPI asynchronousLndAPI() {
         return Mockito.mock(AsynchronousAPI.class);
+    }
+
+    @Bean
+    WalletAppKit walletAppKit() {
+        WalletAppKit walletAppKit = mock(WalletAppKit.class);
+        when(walletAppKit.wallet()).thenReturn(Wallet.createBasic(RegTestParams.get()));
+        when(walletAppKit.params()).thenReturn(RegTestParams.get());
+        return walletAppKit;
     }
 
 }

--- a/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/helper/factory/UserFactory.java
+++ b/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/helper/factory/UserFactory.java
@@ -23,7 +23,7 @@ public class UserFactory {
         return new StandardUser(email, "asd", "asd");
     }
 
-    public static User createAdminUser(String email) {
+    public static AdminUser createAdminUser(String email) {
         return new AdminUser(email, "asd", "asd");
     }
 }

--- a/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/payment/service/PaymentDataServiceTest.java
+++ b/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/payment/service/PaymentDataServiceTest.java
@@ -9,7 +9,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import pl.edu.pjatk.lnpayments.webservice.payment.exception.InconsistentDataException;
+import pl.edu.pjatk.lnpayments.webservice.common.exception.InconsistentDataException;
 import pl.edu.pjatk.lnpayments.webservice.payment.model.entity.Payment;
 import pl.edu.pjatk.lnpayments.webservice.payment.model.entity.PaymentStatus;
 import pl.edu.pjatk.lnpayments.webservice.payment.repository.PaymentRepository;

--- a/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/wallet/resource/WalletResourceIntegrationTest.java
+++ b/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/wallet/resource/WalletResourceIntegrationTest.java
@@ -1,0 +1,135 @@
+package pl.edu.pjatk.lnpayments.webservice.wallet.resource;
+
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import pl.edu.pjatk.lnpayments.webservice.auth.repository.AdminUserRepository;
+import pl.edu.pjatk.lnpayments.webservice.common.entity.AdminUser;
+import pl.edu.pjatk.lnpayments.webservice.helper.config.BaseIntegrationTest;
+import pl.edu.pjatk.lnpayments.webservice.helper.config.IntegrationTestConfiguration;
+import pl.edu.pjatk.lnpayments.webservice.helper.factory.UserFactory;
+import pl.edu.pjatk.lnpayments.webservice.wallet.entity.Wallet;
+import pl.edu.pjatk.lnpayments.webservice.wallet.repository.WalletRepository;
+import pl.edu.pjatk.lnpayments.webservice.wallet.resource.dto.CreateWalletRequest;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ActiveProfiles("test")
+@AutoConfigureMockMvc(addFilters = false)
+@SpringBootTest(classes = IntegrationTestConfiguration.class)
+class WalletResourceIntegrationTest extends BaseIntegrationTest {
+
+    private final static String EMAIL = "test@test.pl";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private AdminUserRepository adminUserRepository;
+
+    @Autowired
+    private WalletRepository walletRepository;
+
+    @AfterEach
+    void tearDown() {
+        walletRepository.deleteAll();
+        adminUserRepository.deleteAll();
+    }
+
+    @Test
+    void shouldReturnCreatedWhenNoIssues() throws Exception {
+        AdminUser admin1 = UserFactory.createAdminUser("admin1@test.pl");
+        AdminUser admin2 = UserFactory.createAdminUser("admin2@test.pl");
+        List<String> adminEmails = List.of(admin1.getEmail(), admin2.getEmail());
+        CreateWalletRequest request = new CreateWalletRequest(1, adminEmails);
+        adminUserRepository.save(admin1);
+        adminUserRepository.save(admin2);
+
+        mockMvc.perform(post("/wallet")
+                        .content(new ObjectMapper().writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isCreated());
+
+        List<Wallet> wallets = walletRepository.findAll();
+        assertThat(wallets.size()).isEqualTo(1);
+        assertThat(wallets.get(0).getAddress()).isEqualTo("2NGEpb541CnfpmA3LEWoehMNCnG94ybTR3F");
+        assertThat(wallets.get(0).getRedeemScript()).isEqualTo("51210346b221a71369a6f70be9660ae560096396cf6813a051fcaf50a418d517007fcb210346b221a71369a6f70be9660ae560096396cf6813a051fcaf50a418d517007fcb52ae");
+        assertThat(wallets.get(0).getScriptPubKey()).isEqualTo("a914fc375c082884b9d7575ac04102d11218406434d287");
+        assertThat(wallets.get(0).getUsers().size()).isEqualTo(2);
+    }
+
+    @Test
+    void shouldReturn409IfWalletAlreadyExists() throws Exception {
+        Wallet wallet = new Wallet("123", "456", "789", Collections.emptyList());
+        walletRepository.save(wallet);
+        CreateWalletRequest request = new CreateWalletRequest(1, List.of(EMAIL));
+
+        mockMvc.perform(post("/wallet")
+                        .content(new ObjectMapper().writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    void shouldReturn404WhenWrongNumberOfAdmins() throws Exception {
+        CreateWalletRequest request = new CreateWalletRequest(1, List.of(EMAIL));
+
+        mockMvc.perform(post("/wallet")
+                        .content(new ObjectMapper().writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void shouldReturn404WhenNoEmailsProvided() throws Exception {
+        CreateWalletRequest request = new CreateWalletRequest(1, Collections.emptyList());
+
+        mockMvc.perform(post("/wallet")
+                        .content(new ObjectMapper().writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void shouldReturn404WhenNotEmailProvided() throws Exception {
+        CreateWalletRequest request = new CreateWalletRequest(1, List.of("not an email"));
+
+        mockMvc.perform(post("/wallet")
+                        .content(new ObjectMapper().writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void shouldReturn404WhenInvalidNumberOfSignatures() throws Exception {
+        CreateWalletRequest request = new CreateWalletRequest(0, List.of(EMAIL));
+
+        mockMvc.perform(post("/wallet")
+                        .content(new ObjectMapper().writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void shouldReturn404WhenMoreSignaturesThanEmails() throws Exception {
+        CreateWalletRequest request = new CreateWalletRequest(5, List.of(EMAIL));
+
+        mockMvc.perform(post("/wallet")
+                        .content(new ObjectMapper().writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
+    }
+
+}

--- a/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/wallet/resource/WalletResourceTest.java
+++ b/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/wallet/resource/WalletResourceTest.java
@@ -1,0 +1,38 @@
+package pl.edu.pjatk.lnpayments.webservice.wallet.resource;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import pl.edu.pjatk.lnpayments.webservice.wallet.resource.dto.CreateWalletRequest;
+import pl.edu.pjatk.lnpayments.webservice.wallet.service.WalletService;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class WalletResourceTest {
+
+    @Mock
+    private WalletService walletService;
+
+    @InjectMocks
+    private WalletResource walletResource;
+
+    @Test
+    void shouldReturnCreatedForNewWalletRequest() {
+        CreateWalletRequest request = new CreateWalletRequest(2, Collections.emptyList());
+
+        ResponseEntity<?> response = walletResource.createWallet(request);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        verify(walletService).createWallet(any(), eq(2));
+    }
+}

--- a/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/wallet/service/BitcoinServiceTest.java
+++ b/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/wallet/service/BitcoinServiceTest.java
@@ -1,0 +1,45 @@
+package pl.edu.pjatk.lnpayments.webservice.wallet.service;
+
+import org.bitcoinj.kits.WalletAppKit;
+import org.bitcoinj.params.RegTestParams;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import pl.edu.pjatk.lnpayments.webservice.common.entity.AdminUser;
+import pl.edu.pjatk.lnpayments.webservice.helper.factory.UserFactory;
+import pl.edu.pjatk.lnpayments.webservice.wallet.entity.Wallet;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class BitcoinServiceTest {
+
+    @Mock
+    private WalletAppKit walletAppKit;
+
+    @InjectMocks
+    private BitcoinService bitcoinService;
+
+    @Test
+    void shouldCreateWallet() {
+        AdminUser admin1 = UserFactory.createAdminUser("admin1@test.pl");
+        AdminUser admin2 = UserFactory.createAdminUser("admin2@test.pl");
+        List<AdminUser> adminUsers = List.of(admin1, admin2);
+        when(walletAppKit.params()).thenReturn(RegTestParams.get());
+        when(walletAppKit.wallet()).thenReturn(Mockito.mock(org.bitcoinj.wallet.Wallet.class));
+
+        Wallet wallet = bitcoinService.createWallet(adminUsers, 2);
+
+        assertThat(wallet.getAddress()).isEqualTo("2N61hyQz11Y8kJ3tjh42w1QAAgmJFdanYEv");
+        assertThat(wallet.getRedeemScript()).isEqualTo("52210346b221a71369a6f70be9660ae560096396cf6813a051fcaf50a418d517007fcb210346b221a71369a6f70be9660ae560096396cf6813a051fcaf50a418d517007fcb52ae");
+        assertThat(wallet.getScriptPubKey()).isEqualTo("a9148c0b2c246ce6738f00f5dd47948966f791042ad887");
+        assertThat(wallet.getUsers()).isEqualTo(adminUsers);
+    }
+
+}

--- a/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/wallet/service/WalletServiceTest.java
+++ b/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/wallet/service/WalletServiceTest.java
@@ -1,0 +1,84 @@
+package pl.edu.pjatk.lnpayments.webservice.wallet.service;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import pl.edu.pjatk.lnpayments.webservice.admin.service.AdminService;
+import pl.edu.pjatk.lnpayments.webservice.common.entity.AdminUser;
+import pl.edu.pjatk.lnpayments.webservice.common.exception.InconsistentDataException;
+import pl.edu.pjatk.lnpayments.webservice.helper.factory.UserFactory;
+import pl.edu.pjatk.lnpayments.webservice.wallet.entity.Wallet;
+import pl.edu.pjatk.lnpayments.webservice.wallet.repository.WalletRepository;
+
+import javax.validation.ValidationException;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class WalletServiceTest {
+
+    @Mock
+    private BitcoinService bitcoinService;
+
+    @Mock
+    private AdminService adminService;
+
+    @Mock
+    private WalletRepository walletRepository;
+
+    @InjectMocks
+    private WalletService walletService;
+
+    @Test
+    void shouldCreateWalletForValidData() {
+        AdminUser admin1 = UserFactory.createAdminUser("admin1@test.pl");
+        AdminUser admin2 = UserFactory.createAdminUser("admin2@test.pl");
+        List<String> adminEmails = List.of(admin1.getEmail(), admin2.getEmail());
+        List<AdminUser> adminUsers = List.of(admin1, admin2);
+        Wallet wallet = new Wallet("123", "456", "789", adminUsers);
+        when(walletRepository.existsByStatus(any())).thenReturn(false);
+        when(adminService.findAllWithKeys(adminEmails)).thenReturn(adminUsers);
+        when(bitcoinService.createWallet(adminUsers, 2)).thenReturn(wallet);
+
+        walletService.createWallet(adminEmails, 2);
+
+        verify(walletRepository).existsByStatus(any());
+        verify(bitcoinService).createWallet(adminUsers, 2);
+        ArgumentCaptor<Wallet> captor = ArgumentCaptor.forClass(Wallet.class);
+        verify(walletRepository).save(captor.capture());
+        Wallet savedWallet = captor.getValue();
+        assertThat(savedWallet.getAddress()).isEqualTo(wallet.getAddress());
+        assertThat(savedWallet.getRedeemScript()).isEqualTo(wallet.getRedeemScript());
+        assertThat(savedWallet.getScriptPubKey()).isEqualTo(wallet.getScriptPubKey());
+        assertThat(savedWallet.getUsers()).isEqualTo(wallet.getUsers());
+    }
+
+    @Test
+    void shouldThrowExceptionWhenWalletAlreadyExists() {
+        when(walletRepository.existsByStatus(any())).thenReturn(true);
+
+        assertThatExceptionOfType(ValidationException.class)
+                .isThrownBy(() -> walletService.createWallet(Collections.emptyList(), 2))
+                .withMessage("Wallet already exists!");
+    }
+
+    @Test
+    void shouldThrowExceptionWhenMoreRequiredSignaturesThanEmails() {
+        List<String> adminEmails = List.of("asd@asd.pl", "dsa@dsa.lp");
+        when(walletRepository.existsByStatus(any())).thenReturn(false);
+
+        assertThatExceptionOfType(InconsistentDataException.class)
+                .isThrownBy(() -> walletService.createWallet(adminEmails, 3))
+                .withMessage("You can't require more confirmations than you have users");
+    }
+
+}


### PR DESCRIPTION
Link to the Jira issue
https://candybear.atlassian.net/browse/LP-97

### Description

I've added new post /wallet endpoint that created wallet. If wallet already exists, throws 409. If bad data, 404.
It takes number of required confirmations and list of emails (users must have keys, right now they are hardcoded).

### How did I test it

Unit and integration tests. Tested with postman.
