### PR TITLE
LP-100 Implement closing and transaction services with endpoints

### DIFF
--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/common/Constants.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/common/Constants.java
@@ -13,6 +13,8 @@ public class Constants {
     public static final String PAYMENTS_WS_PATH = "/payment";
     public static final String ADMIN_PATH = "/admins";
     public static final String WALLET_PATH = "/wallet";
+    public static final String CLOSE_CHANNELS_PATH = "/closeChannels";
+    public static final String TRANSFER_PATH = "/transfer";
 
     public static final String ROOT_USER_EMAIL = "admin@admin.pl";
     public static final String ROOT_USER_PASSWORD = "admin";

--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/common/Constants.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/common/Constants.java
@@ -16,6 +16,8 @@ public class Constants {
     public static final String CLOSE_CHANNELS_PATH = "/closeChannels";
     public static final String TRANSFER_PATH = "/transfer";
 
+    public static final int FORCE_CLOSE_INACTIVE_CHANNEL_DAYS = 7;
+
     public static final String ROOT_USER_EMAIL = "admin@admin.pl";
     public static final String ROOT_USER_PASSWORD = "admin";
 

--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/common/exception/GlobalExceptionHandler.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/common/exception/GlobalExceptionHandler.java
@@ -24,4 +24,9 @@ class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         logger.error(exception);
     }
 
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    @ExceptionHandler(NotFoundException.class)
+    void handleNotFound() {
+    }
+
 }

--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/common/exception/NotFoundException.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/common/exception/NotFoundException.java
@@ -1,0 +1,4 @@
+package pl.edu.pjatk.lnpayments.webservice.common.exception;
+
+public class NotFoundException extends RuntimeException {
+}

--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/wallet/config/WalletConfig.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/wallet/config/WalletConfig.java
@@ -23,8 +23,9 @@ class WalletConfig {
 
     @Bean
     WalletAppKit walletAppKit() {
+        String homePath = System.getProperty("user.home");
         WalletAppKit walletAppKit = new WalletAppKit(
-                Network.valueOf(network.toUpperCase()).getParameters(), new File(walletDirectory), fileName);
+                Network.valueOf(network.toUpperCase()).getParameters(), new File(homePath + walletDirectory), fileName);
         walletAppKit.startAsync();
         walletAppKit.awaitRunning();
         log.info("Bitcoin wallet started!");

--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/wallet/observer/ChannelCloseObserver.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/wallet/observer/ChannelCloseObserver.java
@@ -1,0 +1,34 @@
+package pl.edu.pjatk.lnpayments.webservice.wallet.observer;
+
+import io.grpc.stub.StreamObserver;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.lightningj.lnd.wrapper.message.CloseStatusUpdate;
+import org.springframework.stereotype.Component;
+import pl.edu.pjatk.lnpayments.webservice.payment.exception.LightningException;
+
+import java.util.HexFormat;
+
+@Slf4j
+@Component
+public class ChannelCloseObserver implements StreamObserver<CloseStatusUpdate> {
+
+    @Override
+    @SneakyThrows
+    public void onNext(CloseStatusUpdate value) {
+        if (value.getChanClose().getSuccess()) {
+            log.info("Channel close success: " + HexFormat.of().formatHex(value.getChanClose().getClosingTxid()));
+        }
+    }
+
+    @Override
+    public void onError(Throwable t) {
+        log.error("Error while closing channel: " + t.getMessage());
+        throw new LightningException("Error closing channel", t);
+    }
+
+    @Override
+    public void onCompleted() {
+        log.info("Channel close request completed");
+    }
+}

--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/wallet/repository/WalletRepository.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/wallet/repository/WalletRepository.java
@@ -5,8 +5,12 @@ import org.springframework.stereotype.Repository;
 import pl.edu.pjatk.lnpayments.webservice.wallet.entity.Wallet;
 import pl.edu.pjatk.lnpayments.webservice.wallet.entity.WalletStatus;
 
+import java.util.Optional;
+
 @Repository
 public interface WalletRepository extends JpaRepository<Wallet, Long> {
 
     boolean existsByStatus(WalletStatus status);
+
+    Optional<Wallet> findFirstByStatus(WalletStatus status);
 }

--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/wallet/resource/WalletResource.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/wallet/resource/WalletResource.java
@@ -9,7 +9,7 @@ import pl.edu.pjatk.lnpayments.webservice.wallet.service.WalletService;
 
 import javax.validation.Valid;
 
-import static pl.edu.pjatk.lnpayments.webservice.common.Constants.WALLET_PATH;
+import static pl.edu.pjatk.lnpayments.webservice.common.Constants.*;
 
 @RestController
 @RequestMapping(WALLET_PATH)
@@ -26,6 +26,18 @@ class WalletResource {
     ResponseEntity<?> createWallet(@Valid @RequestBody CreateWalletRequest createWalletRequest) {
         walletService.createWallet(createWalletRequest.getAdminEmails(), createWalletRequest.getMinSignatures());
         return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @PostMapping(CLOSE_CHANNELS_PATH)
+    ResponseEntity<?> closeAllChannels(@RequestParam(required = false) boolean withForce) {
+        walletService.closeAllChannels(withForce);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping(TRANSFER_PATH)
+    ResponseEntity<?> transferFunds() {
+        walletService.transferToWallet();
+        return ResponseEntity.ok().build();
     }
 
 }

--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/wallet/service/ChannelService.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/wallet/service/ChannelService.java
@@ -1,0 +1,74 @@
+package pl.edu.pjatk.lnpayments.webservice.wallet.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.lightningj.lnd.wrapper.*;
+import org.lightningj.lnd.wrapper.message.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import pl.edu.pjatk.lnpayments.webservice.payment.exception.LightningException;
+import pl.edu.pjatk.lnpayments.webservice.wallet.observer.ChannelCloseObserver;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+@Slf4j
+@Service
+public class ChannelService {
+
+    private final SynchronousLndAPI lndAPI;
+    private final AsynchronousLndAPI asyncApi;
+    private final ChannelCloseObserver channelCloseObserver;
+
+    @Autowired
+    public ChannelService(SynchronousLndAPI lndAPI, AsynchronousLndAPI asyncApi, ChannelCloseObserver channelCloseObserver) {
+        this.lndAPI = lndAPI;
+        this.asyncApi = asyncApi;
+        this.channelCloseObserver = channelCloseObserver;
+    }
+
+    /**
+     * Closes all the opened channels. If channel is active, it attempts cooperative close. Otherwise, channel will
+     * remain opened. If channel is closed for more than 7 days or withForce param is true, it will close the
+     * channel with force. In this case funds will be available in wallet after couple days.
+     *
+     * @param withForce forces closing inactive channels with force
+     */
+    public void closeAllChannels(boolean withForce) {
+        try {
+            List<Channel> channels = lndAPI.listChannels(new ListChannelsRequest()).getChannels();
+            for (Channel channel : channels) {
+                closeChannel(channel, withForce);
+            }
+        } catch (StatusException | ValidationException e) {
+            throw new LightningException("Error when closing channels", e);
+        }
+    }
+
+    private void closeChannel(Channel channel, boolean withForce) throws StatusException, ValidationException {
+        String channelPoint = channel.getChannelPoint();
+        CloseChannelRequest closeChannelRequest = new CloseChannelRequest();
+        ChannelPoint point = new ChannelPoint();
+        String[] pointArr = channelPoint.split(":");
+        point.setFundingTxidStr(pointArr[0]);
+        point.setOutputIndex(Integer.parseInt(pointArr[1]));
+        closeChannelRequest.setChannelPoint(point);
+        try {
+            if (!channel.getActive() && (withForce || isInactiveForTooLong(channel))) {
+                closeChannelRequest.setForce(true);
+                log.warn("Force closing {}", channelPoint);
+            }
+            asyncApi.closeChannel(closeChannelRequest, channelCloseObserver);
+        } catch (ServerSideException e) {
+            log.error("Unable to close channel: {}", channelPoint);
+        }
+    }
+
+    private boolean isInactiveForTooLong(Channel channel) throws StatusException, ValidationException {
+        ChannelEdge chanInfo = lndAPI.getChanInfo(channel.getChanId());
+        LocalDate lastActive = LocalDate.ofEpochDay(chanInfo.getLastUpdate());
+        LocalDate now = LocalDate.now();
+        long daysBetween = ChronoUnit.DAYS.between(lastActive, now);
+        return daysBetween >= 7;
+    }
+}

--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/wallet/service/ChannelService.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/wallet/service/ChannelService.java
@@ -12,6 +12,8 @@ import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 
+import static pl.edu.pjatk.lnpayments.webservice.common.Constants.FORCE_CLOSE_INACTIVE_CHANNEL_DAYS;
+
 @Slf4j
 @Service
 public class ChannelService {
@@ -69,6 +71,6 @@ public class ChannelService {
         LocalDate lastActive = LocalDate.ofEpochDay(chanInfo.getLastUpdate());
         LocalDate now = LocalDate.now();
         long daysBetween = ChronoUnit.DAYS.between(lastActive, now);
-        return daysBetween >= 7;
+        return daysBetween >= FORCE_CLOSE_INACTIVE_CHANNEL_DAYS;
     }
 }

--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/wallet/service/TransferService.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/wallet/service/TransferService.java
@@ -1,0 +1,36 @@
+package pl.edu.pjatk.lnpayments.webservice.wallet.service;
+
+import org.lightningj.lnd.wrapper.StatusException;
+import org.lightningj.lnd.wrapper.SynchronousLndAPI;
+import org.lightningj.lnd.wrapper.ValidationException;
+import org.lightningj.lnd.wrapper.message.SendCoinsRequest;
+import org.lightningj.lnd.wrapper.message.SendCoinsResponse;
+import org.springframework.stereotype.Service;
+import pl.edu.pjatk.lnpayments.webservice.common.exception.InconsistentDataException;
+import pl.edu.pjatk.lnpayments.webservice.payment.exception.LightningException;
+
+@Service
+public class TransferService {
+
+    private final SynchronousLndAPI lndAPI;
+
+    public TransferService(SynchronousLndAPI lndAPI) {
+        this.lndAPI = lndAPI;
+    }
+
+    public String transfer(String toAddress) {
+        try {
+            if (lndAPI.walletBalance().getConfirmedBalance() == 0) {
+                throw new InconsistentDataException("Not funds in the wallet");
+            }
+            SendCoinsRequest req = new SendCoinsRequest();
+            req.setSendAll(true);
+            req.setAddr(toAddress);
+            SendCoinsResponse sendCoinsResponse = lndAPI.sendCoins(req);
+            return sendCoinsResponse.getTxid();
+        } catch (StatusException | ValidationException e) {
+            throw new LightningException("Unable to transfer funds", e);
+        }
+    }
+
+}

--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/wallet/service/WalletService.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/wallet/service/WalletService.java
@@ -1,10 +1,12 @@
 package pl.edu.pjatk.lnpayments.webservice.wallet.service;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import pl.edu.pjatk.lnpayments.webservice.admin.service.AdminService;
 import pl.edu.pjatk.lnpayments.webservice.common.entity.AdminUser;
 import pl.edu.pjatk.lnpayments.webservice.common.exception.InconsistentDataException;
+import pl.edu.pjatk.lnpayments.webservice.common.exception.NotFoundException;
 import pl.edu.pjatk.lnpayments.webservice.wallet.entity.Wallet;
 import pl.edu.pjatk.lnpayments.webservice.wallet.entity.WalletStatus;
 import pl.edu.pjatk.lnpayments.webservice.wallet.repository.WalletRepository;
@@ -12,18 +14,27 @@ import pl.edu.pjatk.lnpayments.webservice.wallet.repository.WalletRepository;
 import javax.validation.ValidationException;
 import java.util.List;
 
+@Slf4j
 @Service
 public class WalletService {
 
     private final BitcoinService bitcoinService;
     private final AdminService adminService;
     private final WalletRepository walletRepository;
+    private final TransferService transferService;
+    private final ChannelService channelService;
 
     @Autowired
-    public WalletService(BitcoinService bitcoinService, AdminService adminService, WalletRepository walletRepository) {
+    public WalletService(BitcoinService bitcoinService,
+                         AdminService adminService,
+                         WalletRepository walletRepository,
+                         TransferService transferService,
+                         ChannelService channelService) {
         this.bitcoinService = bitcoinService;
         this.adminService = adminService;
         this.walletRepository = walletRepository;
+        this.transferService = transferService;
+        this.channelService = channelService;
     }
 
     public void createWallet(List<String> adminEmails, int minSignatures) {
@@ -38,4 +49,13 @@ public class WalletService {
         walletRepository.save(wallet);
     }
 
+    public void transferToWallet() {
+        Wallet activeWallet = walletRepository.findFirstByStatus(WalletStatus.ON_DUTY).orElseThrow(NotFoundException::new);
+        String txId = transferService.transfer(activeWallet.getAddress());
+        log.info("Funds were transferred in tx: {}", txId);
+    }
+
+    public void closeAllChannels(boolean withForce) {
+        channelService.closeAllChannels(withForce);
+    }
 }

--- a/webservice/src/main/resources/application.properties
+++ b/webservice/src/main/resources/application.properties
@@ -24,4 +24,4 @@ lnp.auth.jwtSecret=L))::Z.&I!!vA_X.aR<*DScss&xfe.9d[I}{AnyQ+[#ik=W_4_y<?'uVtC@Je
 lnp.wallet.fileName=lnp
 lnp.wallet.network=testnet
 
-lnp.config.workingDirectory=~/.
+lnp.config.workingDirectory=/.lnpayments/.

--- a/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/helper/config/IntegrationTestConfiguration.java
+++ b/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/helper/config/IntegrationTestConfiguration.java
@@ -3,7 +3,7 @@ package pl.edu.pjatk.lnpayments.webservice.helper.config;
 import org.bitcoinj.kits.WalletAppKit;
 import org.bitcoinj.params.RegTestParams;
 import org.bitcoinj.wallet.Wallet;
-import org.lightningj.lnd.wrapper.AsynchronousAPI;
+import org.lightningj.lnd.wrapper.AsynchronousLndAPI;
 import org.lightningj.lnd.wrapper.StatusException;
 import org.lightningj.lnd.wrapper.SynchronousLndAPI;
 import org.lightningj.lnd.wrapper.ValidationException;
@@ -33,8 +33,8 @@ public class IntegrationTestConfiguration {
     }
 
     @Bean
-    AsynchronousAPI asynchronousLndAPI() {
-        return Mockito.mock(AsynchronousAPI.class);
+    AsynchronousLndAPI asynchronousLndAPI() {
+        return Mockito.mock(AsynchronousLndAPI.class);
     }
 
     @Bean

--- a/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/wallet/observer/ChannelCloseObserverTest.java
+++ b/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/wallet/observer/ChannelCloseObserverTest.java
@@ -1,0 +1,79 @@
+package pl.edu.pjatk.lnpayments.webservice.wallet.observer;
+
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import org.assertj.core.groups.Tuple;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.lightningj.lnd.wrapper.message.ChannelCloseUpdate;
+import org.lightningj.lnd.wrapper.message.CloseStatusUpdate;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
+import pl.edu.pjatk.lnpayments.webservice.payment.exception.LightningException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+@ExtendWith(MockitoExtension.class)
+class ChannelCloseObserverTest {
+
+    private ListAppender<ILoggingEvent> logAppender;
+
+    private final ChannelCloseObserver channelCloseObserver = new ChannelCloseObserver();
+
+    @BeforeEach
+    void setUp() {
+        logAppender = new ListAppender<>();
+        logAppender.start();
+        ((Logger) LoggerFactory.getLogger(ChannelCloseObserver.class)).addAppender(logAppender);
+    }
+
+    @Test
+    void shouldLogWhenStatusUpdateIsSuccess() {
+        ChannelCloseUpdate update = new ChannelCloseUpdate();
+        update.setSuccess(true);
+        CloseStatusUpdate closeUpdate = new CloseStatusUpdate();
+        closeUpdate.setChanClose(update);
+
+        channelCloseObserver.onNext(closeUpdate);
+
+        assertThat(logAppender.list)
+                .extracting(ILoggingEvent::getMessage, ILoggingEvent::getLevel)
+                .contains(Tuple.tuple("Channel close success: ", Level.INFO));
+    }
+
+    @Test
+    void shouldNotLogAnythingWhenNoSuccess() {
+        ChannelCloseUpdate update = new ChannelCloseUpdate();
+        update.setSuccess(false);
+        CloseStatusUpdate closeUpdate = new CloseStatusUpdate();
+        closeUpdate.setChanClose(update);
+
+        channelCloseObserver.onNext(closeUpdate);
+
+        assertThat(logAppender.list).isEmpty();
+    }
+
+    @Test
+    void shouldLogMessageOnSuccess() {
+        channelCloseObserver.onCompleted();
+        assertThat(logAppender.list)
+                .extracting(ILoggingEvent::getMessage, ILoggingEvent::getLevel)
+                .contains(Tuple.tuple("Channel close request completed", Level.INFO));
+    }
+
+    @Test
+    void shouldLogAndThrowExceptionOnError() {
+        Throwable throwable = new RuntimeException();
+        assertThatExceptionOfType(LightningException.class)
+                .isThrownBy(() -> channelCloseObserver.onError(throwable))
+                .withMessage("Error closing channel");
+        assertThat(logAppender.list)
+                .extracting(ILoggingEvent::getMessage, ILoggingEvent::getLevel)
+                .contains(Tuple.tuple("Error while closing channel: null", Level.ERROR));
+    }
+}

--- a/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/wallet/resource/WalletResourceTest.java
+++ b/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/wallet/resource/WalletResourceTest.java
@@ -2,6 +2,8 @@ package pl.edu.pjatk.lnpayments.webservice.wallet.resource;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -34,5 +36,22 @@ class WalletResourceTest {
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
         verify(walletService).createWallet(any(), eq(2));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void shouldReturnOkForChannelCloseRequest(boolean force) {
+        ResponseEntity<?> response = walletResource.closeAllChannels(force);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        verify(walletService).closeAllChannels(force);
+    }
+
+    @Test
+    void shouldReturnOkForTransactionRequest() {
+        ResponseEntity<?> response = walletResource.transferFunds();
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        verify(walletService).transferToWallet();
     }
 }

--- a/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/wallet/service/ChannelServiceTest.java
+++ b/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/wallet/service/ChannelServiceTest.java
@@ -1,0 +1,185 @@
+package pl.edu.pjatk.lnpayments.webservice.wallet.service;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import org.assertj.core.groups.Tuple;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.lightningj.lnd.wrapper.*;
+import org.lightningj.lnd.wrapper.message.Channel;
+import org.lightningj.lnd.wrapper.message.ChannelEdge;
+import org.lightningj.lnd.wrapper.message.CloseChannelRequest;
+import org.lightningj.lnd.wrapper.message.ListChannelsResponse;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
+import pl.edu.pjatk.lnpayments.webservice.payment.exception.LightningException;
+import pl.edu.pjatk.lnpayments.webservice.wallet.observer.ChannelCloseObserver;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ChannelServiceTest {
+
+    @Mock
+    private SynchronousLndAPI lndAPI;
+
+    @Mock
+    private AsynchronousLndAPI asyncApi;
+
+    @Mock
+    private ChannelCloseObserver channelCloseObserver;
+
+    @InjectMocks
+    private ChannelService channelService;
+
+    private ListAppender<ILoggingEvent> logAppender;
+
+    @BeforeEach
+    void setUp() {
+        logAppender = new ListAppender<>();
+        logAppender.start();
+        ((Logger) LoggerFactory.getLogger(ChannelService.class)).addAppender(logAppender);
+    }
+
+    @Test
+    void shouldCloseAllChannelsCooperatively() throws StatusException, ValidationException {
+        String channelPoint1 = "channel1:1";
+        String channelPoint2 = "channel2:2";
+        Channel channel1 = createChannel(true, channelPoint1, 1);
+        Channel channel2 = createChannel(true, channelPoint2, 2);
+        ListChannelsResponse listChannelsResponse = new ListChannelsResponse();
+        listChannelsResponse.setChannels(List.of(channel1, channel2));
+        when(lndAPI.listChannels(any())).thenReturn(listChannelsResponse);
+
+        channelService.closeAllChannels(false);
+
+        ArgumentCaptor<CloseChannelRequest> captor = ArgumentCaptor.forClass(CloseChannelRequest.class);
+        verify(asyncApi, times(2)).closeChannel(captor.capture(), eq(channelCloseObserver));
+        List<CloseChannelRequest> values = captor.getAllValues();
+        assertThat(values).hasSize(2);
+        assertThat(values).extracting(CloseChannelRequest::getForce).allMatch(e -> !e);
+        assertThat(values).extracting(CloseChannelRequest::getChannelPoint)
+                .map(point -> point.getFundingTxidStr() + ":" + point.getOutputIndex())
+                .containsAll(List.of(channelPoint1, channelPoint2));
+    }
+
+    @Test
+    void shouldNotCloseChannelThatIsInactiveForLessThanWeekAndNoForce() throws StatusException, ValidationException {
+        String channelPoint1 = "channel1:1";
+        String channelPoint2 = "channel2:2";
+        Channel channel1 = createChannel(true, channelPoint1, 1);
+        Channel channel2 = createChannel(false, channelPoint2, 2);
+        ListChannelsResponse listChannelsResponse = new ListChannelsResponse();
+        listChannelsResponse.setChannels(List.of(channel1, channel2));
+        ChannelEdge channelEdge = new ChannelEdge();
+        channelEdge.setLastUpdate(Math.toIntExact(LocalDate.now().toEpochDay()));
+        when(lndAPI.listChannels(any())).thenReturn(listChannelsResponse);
+        when(lndAPI.getChanInfo(anyLong())).thenReturn(channelEdge);
+
+        channelService.closeAllChannels(false);
+
+        ArgumentCaptor<CloseChannelRequest> captor = ArgumentCaptor.forClass(CloseChannelRequest.class);
+        verify(lndAPI).getChanInfo(anyLong());
+        verify(asyncApi, times(2)).closeChannel(captor.capture(), eq(channelCloseObserver));
+        List<CloseChannelRequest> values = captor.getAllValues();
+        assertThat(values).hasSize(2);
+        assertThat(values).extracting(CloseChannelRequest::getForce).allMatch(e -> !e);
+        assertThat(values).extracting(CloseChannelRequest::getChannelPoint)
+                .map(point -> point.getFundingTxidStr() + ":" + point.getOutputIndex())
+                .containsAll(List.of(channelPoint1, channelPoint2));
+    }
+
+    @Test
+    void shouldAutoForceCloseChannelInactiveForMoreThanWeek() throws Exception {
+        String channelPoint1 = "channel1:1";
+        Channel channel1 = createChannel(false, channelPoint1, 1);
+        ListChannelsResponse listChannelsResponse = new ListChannelsResponse();
+        listChannelsResponse.setChannels(List.of(channel1));
+        ChannelEdge channelEdge = new ChannelEdge();
+        channelEdge.setLastUpdate(Math.toIntExact(LocalDate.now().minusYears(1).toEpochDay()));
+        when(lndAPI.listChannels(any())).thenReturn(listChannelsResponse);
+        when(lndAPI.getChanInfo(anyLong())).thenReturn(channelEdge);
+
+        channelService.closeAllChannels(false);
+
+        ArgumentCaptor<CloseChannelRequest> captor = ArgumentCaptor.forClass(CloseChannelRequest.class);
+        verify(lndAPI).getChanInfo(anyLong());
+        verify(asyncApi).closeChannel(captor.capture(), eq(channelCloseObserver));
+        List<CloseChannelRequest> values = captor.getAllValues();
+        assertThat(values).hasSize(1);
+        assertThat(values).extracting(CloseChannelRequest::getForce).allMatch(e -> e);
+        assertThat(logAppender.list)
+                .extracting(ILoggingEvent::getMessage, ILoggingEvent::getLevel)
+                .contains(Tuple.tuple("Force closing {}", Level.WARN));
+    }
+
+    @Test
+    void shouldForceCloseChannelInactiveForLessThanWeek() throws Exception {
+        String channelPoint1 = "channel1:1";
+        String channelPoint2 = "channel2:2";
+        Channel channel1 = createChannel(true, channelPoint1, 1);
+        Channel channel2 = createChannel(false, channelPoint2, 2);
+        ListChannelsResponse listChannelsResponse = new ListChannelsResponse();
+        listChannelsResponse.setChannels(List.of(channel1, channel2));
+        ChannelEdge channelEdge = new ChannelEdge();
+        channelEdge.setLastUpdate(Math.toIntExact(LocalDate.now().toEpochDay()));
+        when(lndAPI.listChannels(any())).thenReturn(listChannelsResponse);
+
+        channelService.closeAllChannels(true);
+
+        ArgumentCaptor<CloseChannelRequest> captor = ArgumentCaptor.forClass(CloseChannelRequest.class);
+        verify(lndAPI, never()).getChanInfo(anyLong());
+        verify(asyncApi, times(2)).closeChannel(captor.capture(), eq(channelCloseObserver));
+        List<CloseChannelRequest> values = captor.getAllValues();
+        assertThat(values).hasSize(2);
+        assertThat(values.get(0).getForce()).isFalse();
+        assertThat(values.get(1).getForce()).isTrue();
+        assertThat(logAppender.list)
+                .extracting(ILoggingEvent::getMessage, ILoggingEvent::getLevel)
+                .contains(Tuple.tuple("Force closing {}", Level.WARN));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenErrorOnClosingChannel() throws ValidationException, StatusException {
+        when(lndAPI.listChannels(any())).thenThrow(ValidationException.class);
+        assertThatExceptionOfType(LightningException.class)
+                .isThrownBy(() -> channelService.closeAllChannels(false))
+                .withMessage("Error when closing channels");
+    }
+
+    @Test
+    void shouldLogWarningWhenUnableToCloseChannel() throws StatusException, ValidationException {
+        String channelPoint1 = "channel1:1";
+        Channel channel1 = createChannel(true, channelPoint1, 1);
+        ListChannelsResponse listChannelsResponse = new ListChannelsResponse();
+        listChannelsResponse.setChannels(List.of(channel1));
+        when(lndAPI.listChannels(any())).thenReturn(listChannelsResponse);
+        doThrow(ServerSideException.class).when(asyncApi).closeChannel(any(), eq(channelCloseObserver));
+
+        channelService.closeAllChannels(false);
+
+        assertThat(logAppender.list)
+                .extracting(ILoggingEvent::getMessage, ILoggingEvent::getLevel)
+                .contains(Tuple.tuple("Unable to close channel: {}", Level.ERROR));
+    }
+
+    private Channel createChannel(boolean isActive, String channelPoint, long chanId) {
+        Channel channel = new Channel();
+        channel.setChannelPoint(channelPoint);
+        channel.setActive(isActive);
+        channel.setChanId(chanId);
+        return channel;
+    }
+}

--- a/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/wallet/service/TransferServiceTest.java
+++ b/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/wallet/service/TransferServiceTest.java
@@ -1,0 +1,76 @@
+package pl.edu.pjatk.lnpayments.webservice.wallet.service;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.lightningj.lnd.wrapper.StatusException;
+import org.lightningj.lnd.wrapper.SynchronousLndAPI;
+import org.lightningj.lnd.wrapper.ValidationException;
+import org.lightningj.lnd.wrapper.message.SendCoinsRequest;
+import org.lightningj.lnd.wrapper.message.SendCoinsResponse;
+import org.lightningj.lnd.wrapper.message.WalletBalanceResponse;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import pl.edu.pjatk.lnpayments.webservice.common.exception.InconsistentDataException;
+import pl.edu.pjatk.lnpayments.webservice.payment.exception.LightningException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TransferServiceTest {
+
+    @Mock
+    private SynchronousLndAPI lndAPI;
+
+    @InjectMocks
+    private TransferService transferService;
+
+    @Test
+    void shouldTransferIfFundsAreSufficient() throws StatusException, ValidationException {
+        WalletBalanceResponse balanceRequest = new WalletBalanceResponse();
+        balanceRequest.setConfirmedBalance(2137L);
+        SendCoinsResponse sendCoinsResponse = new SendCoinsResponse();
+        sendCoinsResponse.setTxid("tx");
+        when(lndAPI.walletBalance()).thenReturn(balanceRequest);
+        when(lndAPI.sendCoins(any())).thenReturn(sendCoinsResponse);
+
+        String txId = transferService.transfer("addr");
+
+        assertThat(txId).isEqualTo("tx");
+        ArgumentCaptor<SendCoinsRequest> sendCoinsRequestArgumentCaptor = ArgumentCaptor.forClass(SendCoinsRequest.class);
+        verify(lndAPI).sendCoins(sendCoinsRequestArgumentCaptor.capture());
+        SendCoinsRequest sendCoinsRequest = sendCoinsRequestArgumentCaptor.getValue();
+        assertThat(sendCoinsRequest.getAddr()).isEqualTo("addr");
+        assertThat(sendCoinsRequest.getSendAll()).isTrue();
+    }
+
+    @Test
+    void shouldThrowExceptionWhenNoFundsAvailable() throws StatusException, ValidationException {
+        WalletBalanceResponse balanceRequest = new WalletBalanceResponse();
+        balanceRequest.setConfirmedBalance(0L);
+        when(lndAPI.walletBalance()).thenReturn(balanceRequest);
+
+        assertThatExceptionOfType(InconsistentDataException.class)
+                .isThrownBy(() -> transferService.transfer(""))
+                .withMessage("Not funds in the wallet");
+    }
+
+    @Test
+    void shouldThrowExceptionWhenCoinSendFailed() throws StatusException, ValidationException {
+        Class<ValidationException> exceptionClass = ValidationException.class;
+        WalletBalanceResponse balanceRequest = new WalletBalanceResponse();
+        balanceRequest.setConfirmedBalance(2137L);
+        when(lndAPI.walletBalance()).thenReturn(balanceRequest);
+        when(lndAPI.sendCoins(any())).thenThrow(exceptionClass);
+
+        assertThatExceptionOfType(LightningException.class)
+                .isThrownBy(() -> transferService.transfer(""))
+                .withMessage("Unable to transfer funds")
+                .withCauseExactlyInstanceOf(exceptionClass);
+    }
+}


### PR DESCRIPTION
Link to the Jira issue
https://candybear.atlassian.net/browse/LP-100

### Description

I've created endpoints and services for closing channels and transferring funds to bitcoin walled. You can close channel cooperatively or with force.

### How did I test it

Added unit tests and tested manually. Integration tests are rather poor, because they would repeat the same logic from the services, as we don't have real lnd api in there.
