### PR TITLE
LP-161 Implement wallet recreation flow

### DIFF
--- a/webservice/pom.xml
+++ b/webservice/pom.xml
@@ -232,6 +232,7 @@
                         <configuration>
                             <excludes>
                                 <exclude>**/*Config.*</exclude>
+                                <exclude>**/*config*/*</exclude>
                                 <exclude>**/*Application.*</exclude>
                                 <exclude>**/*Settings.*</exclude>
                                 <exclude>**/*_.*</exclude>

--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/notification/model/NotificationType.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/notification/model/NotificationType.java
@@ -1,5 +1,6 @@
 package pl.edu.pjatk.lnpayments.webservice.notification.model;
 
 public enum NotificationType {
-    TRANSACTION
+    TRANSACTION,
+    WALLET_RECREATION
 }

--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/notification/strategy/WalletRecreationHandler.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/notification/strategy/WalletRecreationHandler.java
@@ -1,0 +1,46 @@
+package pl.edu.pjatk.lnpayments.webservice.notification.strategy;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import pl.edu.pjatk.lnpayments.webservice.notification.model.Notification;
+import pl.edu.pjatk.lnpayments.webservice.notification.model.NotificationType;
+import pl.edu.pjatk.lnpayments.webservice.notification.repository.dto.ConfirmationDetails;
+import pl.edu.pjatk.lnpayments.webservice.transaction.model.TransactionStatus;
+import pl.edu.pjatk.lnpayments.webservice.wallet.service.WalletService;
+
+@Component
+public class WalletRecreationHandler implements NotificationHandler {
+
+    private final TransactionHandler transactionHandler;
+    private final WalletService walletService;
+
+    @Autowired
+    public WalletRecreationHandler(TransactionHandler transactionHandler, WalletService walletService) {
+        this.transactionHandler = transactionHandler;
+        this.walletService = walletService;
+    }
+
+    @Override
+    public void confirm(Notification notification, ConfirmationDetails data) {
+        transactionHandler.confirm(notification, data);
+        if (notification.getTransaction().isConfirmed() &&
+                notification.getTransaction().getStatus() == TransactionStatus.APPROVED) {
+            walletService.swapWallets();
+        } else if (notification.getTransaction().getStatus() == TransactionStatus.FAILED) {
+            walletService.deleteWalletInCreation();
+        }
+    }
+
+    @Override
+    public void deny(Notification notification) {
+        transactionHandler.deny(notification);
+        if(notification.getTransaction().isDenied()) {
+            walletService.deleteWalletInCreation();
+        }
+    }
+
+    @Override
+    public NotificationType getType() {
+        return NotificationType.WALLET_RECREATION;
+    }
+}

--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/transaction/repository/TransactionRepository.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/transaction/repository/TransactionRepository.java
@@ -12,6 +12,8 @@ import java.util.Optional;
 @Repository
 public interface TransactionRepository extends JpaRepository<Transaction, Long> {
 
+    boolean existsByStatus(TransactionStatus status);
+
     Optional<Transaction> findFirstByStatus(TransactionStatus status);
 
     Page<Transaction> findAllByStatusNot(TransactionStatus status, Pageable pageable);

--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/transaction/resource/TransactionResource.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/transaction/resource/TransactionResource.java
@@ -7,7 +7,6 @@ import org.springframework.data.web.SortDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import pl.edu.pjatk.lnpayments.webservice.payment.model.entity.Payment_;
 import pl.edu.pjatk.lnpayments.webservice.transaction.model.Transaction_;
 import pl.edu.pjatk.lnpayments.webservice.transaction.resource.dto.TransactionRequest;
 import pl.edu.pjatk.lnpayments.webservice.transaction.resource.dto.TransactionResponse;
@@ -30,7 +29,7 @@ class TransactionResource {
 
     @PostMapping
     ResponseEntity<?> createTransaction(@RequestBody @Valid TransactionRequest request) {
-        transactionService.createTransaction(request);
+        transactionService.createTransaction(request.getTargetAddress(), request.getAmount());
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 

--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/transaction/service/TransactionService.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/transaction/service/TransactionService.java
@@ -103,6 +103,10 @@ public class TransactionService {
                 .forEach(notification -> notification.setStatus(NotificationStatus.EXPIRED));
     }
 
+    public boolean isTransactionInProgress() {
+        return transactionRepository.existsByStatus(TransactionStatus.PENDING);
+    }
+
     private Function<AdminUser, Notification> createNotificationFunction(
             Transaction transaction, NotificationType notificationType) {
         return user -> new Notification(

--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/transaction/service/TransactionService.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/transaction/service/TransactionService.java
@@ -15,12 +15,11 @@ import pl.edu.pjatk.lnpayments.webservice.transaction.model.Transaction;
 import pl.edu.pjatk.lnpayments.webservice.transaction.model.TransactionStatus;
 import pl.edu.pjatk.lnpayments.webservice.transaction.repository.TransactionRepository;
 import pl.edu.pjatk.lnpayments.webservice.transaction.resource.dto.TransactionDetails;
-import pl.edu.pjatk.lnpayments.webservice.transaction.resource.dto.TransactionRequest;
 import pl.edu.pjatk.lnpayments.webservice.transaction.resource.dto.TransactionResponse;
 import pl.edu.pjatk.lnpayments.webservice.wallet.entity.Wallet;
 import pl.edu.pjatk.lnpayments.webservice.wallet.exception.BroadcastException;
 import pl.edu.pjatk.lnpayments.webservice.wallet.service.BitcoinService;
-import pl.edu.pjatk.lnpayments.webservice.wallet.service.WalletService;
+import pl.edu.pjatk.lnpayments.webservice.wallet.service.WalletDataService;
 
 import javax.transaction.Transactional;
 import java.util.List;
@@ -34,41 +33,48 @@ public class TransactionService {
     private final TransactionRepository transactionRepository;
     private final BitcoinService bitcoinService;
     private final NotificationSocketController notificationSocketController;
-    private final WalletService walletService;
+    private final WalletDataService walletDataService;
     private final TransactionConverter transactionConverter;
 
     @Autowired
     public TransactionService(TransactionRepository transactionRepository,
                               BitcoinService bitcoinService,
                               NotificationSocketController notificationSocketController,
-                              WalletService walletService,
+                              WalletDataService walletDataService,
                               TransactionConverter transactionConverter) {
         this.transactionRepository = transactionRepository;
         this.bitcoinService = bitcoinService;
         this.notificationSocketController = notificationSocketController;
-        this.walletService = walletService;
+        this.walletDataService = walletDataService;
         this.transactionConverter = transactionConverter;
     }
 
     @Transactional
-    public void createTransaction(TransactionRequest transactionRequest) {
-        if (transactionRepository.findFirstByStatus(TransactionStatus.PENDING).isPresent()) {
-            throw new InconsistentDataException("Pending transaction already exists!");
-        }
-        Wallet wallet = walletService.getActiveWallet();
+    public void createTransaction(String targetAddress, long amount) {
+        Wallet wallet = validateAndObtainWallet();
         Transaction transaction = bitcoinService.createTransaction(
                 wallet.getAddress(),
-                transactionRequest.getTargetAddress(),
-                transactionRequest.getAmount()
+                targetAddress,
+                amount
         );
-        transaction.setRequiredApprovals(wallet.getMinSignatures());
-        transactionRepository.save(transaction);
-        List<AdminUser> users = wallet.getUsers();
-        List<Notification> notifications = users.stream()
-                .map(createNotificationFunction(transaction))
-                .collect(Collectors.toList());
-        transaction.setNotifications(notifications);
-        notificationSocketController.sendAllNotifications(notifications);
+        finishTransaction(wallet, transaction, NotificationType.TRANSACTION);
+    }
+
+    /**
+     * Creates sweep transaction, that spends all available inputs. As for now only used for wallet recreation.
+     * If we ever want to use it as a normal functionality, this component would require refactor
+     * (like using template design pattern).
+     *
+     * @param targetAddress  Address to send funds to.
+     */
+    @Transactional
+    public void createTransaction(String targetAddress) {
+        Wallet wallet = validateAndObtainWallet();
+        Transaction transaction = bitcoinService.createTransaction(
+                wallet.getAddress(),
+                targetAddress
+        );
+        finishTransaction(wallet, transaction, NotificationType.WALLET_RECREATION);
     }
 
     public TransactionResponse findTransactions(Pageable pageable) {
@@ -80,7 +86,7 @@ public class TransactionService {
     }
 
     public void broadcastTransaction(Transaction transaction) {
-        Wallet wallet = walletService.getActiveWallet();
+        Wallet wallet = walletDataService.getActiveWallet();
         try {
             bitcoinService.broadcast(transaction.getRawTransaction(), wallet.getRedeemScript());
             transaction.setStatus(TransactionStatus.APPROVED);
@@ -97,11 +103,30 @@ public class TransactionService {
                 .forEach(notification -> notification.setStatus(NotificationStatus.EXPIRED));
     }
 
-    private Function<AdminUser, Notification> createNotificationFunction(Transaction transaction) {
+    private Function<AdminUser, Notification> createNotificationFunction(
+            Transaction transaction, NotificationType notificationType) {
         return user -> new Notification(
                 user, transaction,
                 "Transaction confirmation",
-                NotificationType.TRANSACTION
+                notificationType
         );
+    }
+
+    private Wallet validateAndObtainWallet() {
+        if (transactionRepository.findFirstByStatus(TransactionStatus.PENDING).isPresent()) {
+            throw new InconsistentDataException("Pending transaction already exists!");
+        }
+        return walletDataService.getActiveWallet();
+    }
+
+    private void finishTransaction(Wallet wallet, Transaction transaction, NotificationType type) {
+        transaction.setRequiredApprovals(wallet.getMinSignatures());
+        transactionRepository.save(transaction);
+        List<AdminUser> users = wallet.getUsers();
+        List<Notification> notifications = users.stream()
+                .map(createNotificationFunction(transaction, type))
+                .collect(Collectors.toList());
+        transaction.setNotifications(notifications);
+        notificationSocketController.sendAllNotifications(notifications);
     }
 }

--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/wallet/entity/Wallet.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/wallet/entity/Wallet.java
@@ -43,7 +43,6 @@ public class Wallet {
         this.scriptPubKey = scriptPubKey;
         this.address = address;
         this.users = users;
-        this.status = WalletStatus.ON_DUTY;
         this.minSignatures = minSignatures;
     }
 }

--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/wallet/entity/WalletStatus.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/wallet/entity/WalletStatus.java
@@ -2,5 +2,6 @@ package pl.edu.pjatk.lnpayments.webservice.wallet.entity;
 
 public enum WalletStatus {
     REMOVED,
-    ON_DUTY
+    ON_DUTY,
+    IN_CREATION
 }

--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/wallet/repository/WalletRepository.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/wallet/repository/WalletRepository.java
@@ -13,4 +13,6 @@ public interface WalletRepository extends JpaRepository<Wallet, Long> {
     boolean existsByStatus(WalletStatus status);
 
     Optional<Wallet> findFirstByStatus(WalletStatus status);
+
+    void deleteByStatus(WalletStatus status);
 }

--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/wallet/service/BitcoinService.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/wallet/service/BitcoinService.java
@@ -89,6 +89,25 @@ public class BitcoinService {
                 .build();
     }
 
+    public pl.edu.pjatk.lnpayments.webservice.transaction.model.Transaction createTransaction(
+            String sourceAddress, String targetAddress) {
+        NetworkParameters params = walletAppKit.params();
+        Address fromAddress = Address.fromString(params, sourceAddress);
+        Address toAddress = Address.fromString(params, targetAddress);
+        Transaction payingToMultisigTx = buildTxWithInputs(params, fromAddress);
+        Coin inputSum = payingToMultisigTx.getInputSum();
+        Coin finalSum = inputSum.subtract(REFERENCE_DEFAULT_MIN_TX_FEE);
+        TransactionOutput output = new TransactionOutput(params, payingToMultisigTx, finalSum, toAddress);
+        payingToMultisigTx.addOutput(output);
+        return pl.edu.pjatk.lnpayments.webservice.transaction.model.Transaction.builder()
+                .rawTransaction(payingToMultisigTx.toHexString())
+                .sourceAddress(sourceAddress)
+                .targetAddress(targetAddress)
+                .fee(payingToMultisigTx.getFee().value)
+                .inputValue(finalSum.value)
+                .build();
+    }
+
     private Transaction buildTxWithInputs(NetworkParameters params, Address fromAddress) {
         Transaction payingToMultisigTx = new Transaction(params);
         walletAppKit.wallet()

--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/wallet/service/WalletDataService.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/wallet/service/WalletDataService.java
@@ -1,0 +1,45 @@
+package pl.edu.pjatk.lnpayments.webservice.wallet.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import pl.edu.pjatk.lnpayments.webservice.common.exception.NotFoundException;
+import pl.edu.pjatk.lnpayments.webservice.wallet.entity.Wallet;
+import pl.edu.pjatk.lnpayments.webservice.wallet.entity.WalletStatus;
+import pl.edu.pjatk.lnpayments.webservice.wallet.repository.WalletRepository;
+
+@Service
+public class WalletDataService {
+
+    private final WalletRepository walletRepository;
+
+    @Autowired
+    WalletDataService(WalletRepository walletRepository) {
+        this.walletRepository = walletRepository;
+    }
+
+    public Wallet save(Wallet wallet) {
+        return walletRepository.save(wallet);
+    }
+
+    public Wallet getActiveWallet() {
+        return walletRepository.findFirstByStatus(WalletStatus.ON_DUTY)
+                .orElseThrow(() -> new NotFoundException("Active wallet not found"));
+    }
+
+    public Wallet getWalletInCreation() {
+        return walletRepository.findFirstByStatus(WalletStatus.IN_CREATION)
+                .orElseThrow(() -> new NotFoundException("Wallet in creation not found"));
+    }
+
+    public void deleteCreatingWallet() {
+        walletRepository.deleteByStatus(WalletStatus.IN_CREATION);
+    }
+
+    public boolean existsActive() {
+        return walletRepository.existsByStatus(WalletStatus.ON_DUTY);
+    }
+
+    public boolean existInCreation() {
+        return walletRepository.existsByStatus(WalletStatus.IN_CREATION);
+    }
+}

--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/wallet/service/WalletService.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/wallet/service/WalletService.java
@@ -7,12 +7,12 @@ import pl.edu.pjatk.lnpayments.webservice.admin.converter.AdminConverter;
 import pl.edu.pjatk.lnpayments.webservice.admin.service.AdminService;
 import pl.edu.pjatk.lnpayments.webservice.common.entity.AdminUser;
 import pl.edu.pjatk.lnpayments.webservice.common.exception.InconsistentDataException;
-import pl.edu.pjatk.lnpayments.webservice.common.exception.NotFoundException;
+import pl.edu.pjatk.lnpayments.webservice.transaction.service.TransactionService;
 import pl.edu.pjatk.lnpayments.webservice.wallet.entity.Wallet;
 import pl.edu.pjatk.lnpayments.webservice.wallet.entity.WalletStatus;
-import pl.edu.pjatk.lnpayments.webservice.wallet.repository.WalletRepository;
 import pl.edu.pjatk.lnpayments.webservice.wallet.resource.dto.WalletDetails;
 
+import javax.transaction.Transactional;
 import javax.validation.ValidationException;
 import java.util.List;
 
@@ -22,41 +22,43 @@ public class WalletService {
 
     private final BitcoinService bitcoinService;
     private final AdminService adminService;
-    private final WalletRepository walletRepository;
     private final LightningWalletService lightningWalletService;
     private final ChannelService channelService;
     private final AdminConverter adminConverter;
+    private final TransactionService transactionService;
+    private final WalletDataService walletDataService;
 
     @Autowired
     public WalletService(BitcoinService bitcoinService,
                          AdminService adminService,
-                         WalletRepository walletRepository,
                          LightningWalletService lightningWalletService,
                          ChannelService channelService,
-                         AdminConverter adminConverter) {
+                         AdminConverter adminConverter,
+                         TransactionService transactionService,
+                         WalletDataService walletDataService) {
         this.bitcoinService = bitcoinService;
         this.adminService = adminService;
-        this.walletRepository = walletRepository;
         this.lightningWalletService = lightningWalletService;
         this.channelService = channelService;
         this.adminConverter = adminConverter;
+        this.transactionService = transactionService;
+        this.walletDataService = walletDataService;
     }
 
+    @Transactional
     public void createWallet(List<String> adminEmails, int minSignatures) {
-        if (walletRepository.existsByStatus(WalletStatus.ON_DUTY)) {
-            throw new ValidationException("Wallet already exists!");
+        if (walletDataService.existsActive()) {
+            recreateWallet(adminEmails, minSignatures);
+        } else {
+            buildNewWallet(adminEmails, minSignatures, WalletStatus.ON_DUTY);
         }
-        if (adminEmails.size() < minSignatures) {
-            throw new InconsistentDataException("You can't require more confirmations than you have users");
-        }
-        List<AdminUser> adminUsers = adminService.findAllWithKeys(adminEmails);
-        Wallet wallet = bitcoinService.createWallet(adminUsers, minSignatures);
-        adminUsers.forEach(user -> user.setWallet(wallet));
-        walletRepository.save(wallet);
     }
 
     public void transferToWallet() {
-        Wallet activeWallet = getActiveWallet();
+        if (walletDataService.existInCreation()) {
+            throw new ValidationException("When wallet is in creation, transfer is unavailable");
+        }
+        Wallet activeWallet = walletDataService.getActiveWallet();
         String txId = lightningWalletService.transfer(activeWallet.getAddress());
         log.info("Funds were transferred in tx: {}", txId);
     }
@@ -66,7 +68,7 @@ public class WalletService {
     }
 
     public WalletDetails getDetails() {
-        Wallet activeWallet = getActiveWallet();
+        Wallet activeWallet = walletDataService.getActiveWallet();
         return WalletDetails.builder()
                 .address(activeWallet.getAddress())
                 .admins(adminConverter.convertAllToDto(activeWallet.getUsers()))
@@ -76,8 +78,40 @@ public class WalletService {
                 .build();
     }
 
-    public Wallet getActiveWallet() {
-        return walletRepository.findFirstByStatus(WalletStatus.ON_DUTY)
-                .orElseThrow(() -> new NotFoundException("Active wallet not found"));
+
+    @Transactional
+    public void swapWallets() {
+        Wallet oldWallet = walletDataService.getActiveWallet();
+        Wallet newWallet = walletDataService.getWalletInCreation();
+        oldWallet.setStatus(WalletStatus.REMOVED);
+        newWallet.setStatus(WalletStatus.ON_DUTY);
+    }
+
+    public void deleteWalletInCreation() {
+        walletDataService.deleteCreatingWallet();
+    }
+
+    private void recreateWallet(List<String> adminEmails, int minSignatures) {
+        if (walletDataService.existInCreation()) {
+            throw new ValidationException("There is already a wallet in creation process");
+        }
+        List<AdminUser> adminUsers = adminService.findAllWithKeys(adminEmails);
+        Wallet activeWallet = walletDataService.getActiveWallet();
+        if (minSignatures == activeWallet.getMinSignatures() && adminUsers.containsAll(activeWallet.getUsers())) {
+            throw new InconsistentDataException("Wallet cannot be recreated with the same data");
+        }
+        Wallet newWallet = buildNewWallet(adminEmails, minSignatures, WalletStatus.IN_CREATION);
+        transactionService.createTransaction(newWallet.getAddress());
+    }
+
+    private Wallet buildNewWallet(List<String> adminEmails, int minSignatures, WalletStatus status) {
+        if (adminEmails.size() < minSignatures) {
+            throw new InconsistentDataException("You can't require more confirmations than you have users");
+        }
+        List<AdminUser> adminUsers = adminService.findAllWithKeys(adminEmails);
+        Wallet wallet = bitcoinService.createWallet(adminUsers, minSignatures);
+        wallet.setStatus(status);
+        adminUsers.forEach(user -> user.setWallet(wallet));
+        return walletDataService.save(wallet);
     }
 }

--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/wallet/service/WalletService.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/wallet/service/WalletService.java
@@ -95,6 +95,9 @@ public class WalletService {
         if (walletDataService.existInCreation()) {
             throw new ValidationException("There is already a wallet in creation process");
         }
+        if(transactionService.isTransactionInProgress()) {
+            throw new ValidationException("There is already a transaction in progress");
+        }
         List<AdminUser> adminUsers = adminService.findAllWithKeys(adminEmails);
         Wallet activeWallet = walletDataService.getActiveWallet();
         if (minSignatures == activeWallet.getMinSignatures() && adminUsers.containsAll(activeWallet.getUsers())) {

--- a/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/notification/strategy/WalletRecreationHandlerTest.java
+++ b/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/notification/strategy/WalletRecreationHandlerTest.java
@@ -1,0 +1,151 @@
+package pl.edu.pjatk.lnpayments.webservice.notification.strategy;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import pl.edu.pjatk.lnpayments.webservice.common.entity.AdminUser;
+import pl.edu.pjatk.lnpayments.webservice.notification.model.Notification;
+import pl.edu.pjatk.lnpayments.webservice.notification.model.NotificationStatus;
+import pl.edu.pjatk.lnpayments.webservice.notification.model.NotificationType;
+import pl.edu.pjatk.lnpayments.webservice.notification.repository.dto.ConfirmationDetails;
+import pl.edu.pjatk.lnpayments.webservice.transaction.model.Transaction;
+import pl.edu.pjatk.lnpayments.webservice.transaction.model.TransactionStatus;
+import pl.edu.pjatk.lnpayments.webservice.wallet.service.WalletService;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+import static pl.edu.pjatk.lnpayments.webservice.helper.factory.UserFactory.createAdminUser;
+
+@ExtendWith(MockitoExtension.class)
+class WalletRecreationHandlerTest {
+
+    @Mock
+    private WalletService walletService;
+
+    @Mock
+    private TransactionHandler transactionHandler;
+
+    @InjectMocks
+    private WalletRecreationHandler walletRecreationHandler;
+
+    @Test
+    void shouldConfirmAndSwapWalletsIfTransactionIsConfirmed() {
+        Transaction transaction = new Transaction();
+        transaction.setRequiredApprovals(1);
+        transaction.setId(1L);
+        AdminUser user = createAdminUser("test@test.pl");
+        user.setPublicKey("pub");
+        user.setId(1L);
+        Notification notification = new Notification(user, transaction, "message", NotificationType.WALLET_RECREATION);
+        transaction.setNotifications(List.of(notification));
+        ConfirmationDetails details = new ConfirmationDetails("rawtx", 0L);
+        doAnswer(a -> {
+            notification.setStatus(NotificationStatus.CONFIRMED);
+            transaction.setStatus(TransactionStatus.APPROVED);
+            return null;
+        }).when(transactionHandler).confirm(notification, details);
+
+        walletRecreationHandler.confirm(notification, details);
+
+        verify(transactionHandler).confirm(notification, details);
+        verify(walletService).swapWallets();
+    }
+
+    @Test
+    void shouldConfirmButNotSwapWallets() {
+        Transaction transaction = new Transaction();
+        transaction.setRequiredApprovals(3);
+        transaction.setId(1L);
+        AdminUser user = createAdminUser("test@test.pl");
+        user.setPublicKey("pub");
+        user.setId(1L);
+        Notification notification = new Notification(user, transaction, "message", NotificationType.WALLET_RECREATION);
+        transaction.setNotifications(List.of(notification));
+        ConfirmationDetails details = new ConfirmationDetails("rawtx", 0L);
+        doAnswer(a -> {
+            notification.setStatus(NotificationStatus.CONFIRMED);
+            return null;
+        }).when(transactionHandler).confirm(notification, details);
+
+        walletRecreationHandler.confirm(notification, details);
+
+        verify(transactionHandler).confirm(notification, details);
+        verify(walletService, never()).swapWallets();
+    }
+
+    @Test
+    void shouldDenyAndRemoveWalletIfTransactionIsDenied() {
+        Transaction transaction = new Transaction();
+        transaction.setRequiredApprovals(1);
+        transaction.setId(1L);
+        AdminUser user = createAdminUser("test@test.pl");
+        user.setPublicKey("pub");
+        user.setId(1L);
+        Notification notification = new Notification(user, transaction, "message", NotificationType.WALLET_RECREATION);
+        transaction.setNotifications(List.of(notification));
+        doAnswer(a -> {
+            notification.setStatus(NotificationStatus.DENIED);
+            return null;
+        }).when(transactionHandler).deny(notification);
+
+        walletRecreationHandler.deny(notification);
+
+        verify(transactionHandler).deny(notification);
+        verify(walletService).deleteWalletInCreation();
+    }
+
+    @Test
+    void shouldDenyButNotDelete() {
+        Transaction transaction = new Transaction();
+        transaction.setRequiredApprovals(3);
+        transaction.setId(1L);
+        AdminUser user = createAdminUser("test@test.pl");
+        user.setPublicKey("pub");
+        user.setId(1L);
+        Notification notification = new Notification(user, transaction, "message", NotificationType.WALLET_RECREATION);
+        transaction.setNotifications(List.of(notification));
+        doAnswer(a -> {
+            notification.setStatus(NotificationStatus.DENIED);
+            return null;
+        }).when(transactionHandler).deny(notification);
+
+        walletRecreationHandler.deny(notification);
+
+        verify(transactionHandler).deny(notification);
+        verify(walletService, never()).deleteWalletInCreation();
+    }
+
+    @Test
+    void shouldNotSwapWalletsWhenTransactionIsFailed() {
+        Transaction transaction = new Transaction();
+        transaction.setRequiredApprovals(1);
+        transaction.setId(1L);
+        AdminUser user = createAdminUser("test@test.pl");
+        user.setPublicKey("pub");
+        user.setId(1L);
+        Notification notification = new Notification(user, transaction, "message", NotificationType.WALLET_RECREATION);
+        transaction.setNotifications(List.of(notification));
+        ConfirmationDetails details = new ConfirmationDetails("rawtx", 0L);
+        doAnswer(a -> {
+            notification.setStatus(NotificationStatus.CONFIRMED);
+            transaction.setStatus(TransactionStatus.FAILED);
+            return null;
+        }).when(transactionHandler).confirm(notification, details);
+
+        walletRecreationHandler.confirm(notification, details);
+
+        verify(transactionHandler).confirm(notification, details);
+        verify(walletService, never()).swapWallets();
+        verify(walletService).deleteWalletInCreation();
+    }
+
+    @Test
+    void shouldReturnCorrectType() {
+        NotificationType type = walletRecreationHandler.getType();
+        assertThat(type).isEqualTo(NotificationType.WALLET_RECREATION);
+    }
+}

--- a/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/transaction/resource/TransactionResourceIntegrationTest.java
+++ b/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/transaction/resource/TransactionResourceIntegrationTest.java
@@ -23,6 +23,7 @@ import pl.edu.pjatk.lnpayments.webservice.transaction.model.TransactionStatus;
 import pl.edu.pjatk.lnpayments.webservice.transaction.repository.TransactionRepository;
 import pl.edu.pjatk.lnpayments.webservice.transaction.resource.dto.TransactionRequest;
 import pl.edu.pjatk.lnpayments.webservice.wallet.entity.Wallet;
+import pl.edu.pjatk.lnpayments.webservice.wallet.entity.WalletStatus;
 import pl.edu.pjatk.lnpayments.webservice.wallet.repository.WalletRepository;
 
 import java.time.Instant;
@@ -77,6 +78,7 @@ class TransactionResourceIntegrationTest extends BaseIntegrationTest {
                 .minSignatures(1)
                 .address("2N9fb1HjNWYs77MHhvnWGHunDeFwMMeYxo4")
                 .build();
+        wallet.setStatus(WalletStatus.ON_DUTY);
         walletRepository.save(wallet);
         user.setWallet(wallet);
         userRepository.save(user);
@@ -122,6 +124,7 @@ class TransactionResourceIntegrationTest extends BaseIntegrationTest {
                 .users(List.of(user))
                 .address("2N9fb1HjNWYs77MHhvnWGHunDeFwMMeYxo4")
                 .build();
+        wallet.setStatus(WalletStatus.ON_DUTY);
         user.setWallet(wallet);
         walletRepository.save(wallet);
         org.bitcoinj.core.Transaction transaction1 = new org.bitcoinj.core.Transaction(params, HexFormat.of().parseHex("01000000012a3c2133f9b678877ae4afd5a982bdc453d5e86749722fe189acd5a2c97660f300000000d9004730440220407e37b9e31d1200f2abe0e393338db0aa1bd21783ccc06f68aee92aae529a790220627b7052a9bc8dd4dc5c55e4f631a97296b3e1ddfe19fb2b5528cb0d130f0c260147304402200a505e3526df75a3addf672c366f79fe28b3f0220f063f78db8ae4a921d0e97a02207aefa698d8f1a984b93fff4480cd30b5e174832e3dab84365a4766615845c8580147522102ab7358f9fba8b2661dc6b489ced6cac0d620eb1de82100e6cf40c404ee44dc3a210346b221a71369a6f70be9660ae560096396cf6813a051fcaf50a418d517007fcb52aeffffffff026400000000000000160014a9619fc4a9c6d2d36eb6ace4d5bc9abdbebc8f5cc42200000000000017a914b41d8a3e10f6a407ae80ceea45a8eae867ac78598700000000"));

--- a/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/transaction/resource/TransactionResourceTest.java
+++ b/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/transaction/resource/TransactionResourceTest.java
@@ -29,7 +29,7 @@ class TransactionResourceTest {
         ResponseEntity<?> transaction = transactionResource.createTransaction(request);
 
         assertThat(transaction.getStatusCode()).isEqualTo(HttpStatus.CREATED);
-        verify(transactionService).createTransaction(request);
+        verify(transactionService).createTransaction(request.getTargetAddress(), request.getAmount());
     }
 
     @Test

--- a/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/transaction/service/TransactionServiceTest.java
+++ b/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/transaction/service/TransactionServiceTest.java
@@ -2,6 +2,8 @@ package pl.edu.pjatk.lnpayments.webservice.transaction.service;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.InjectMocks;
@@ -252,6 +254,16 @@ class TransactionServiceTest {
         assertThat(transaction.getStatus()).isEqualTo(TransactionStatus.DENIED);
         assertThat(transaction.getNotifications()).extracting(Notification::getStatus).filteredOn(status -> status == NotificationStatus.EXPIRED).hasSize(2);
         assertThat(transaction.getNotifications()).extracting(Notification::getStatus).filteredOn(status -> status == NotificationStatus.CONFIRMED).hasSize(1);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void shouldReturnBooleanIfTransactionIsInProgress(boolean expected) {
+        when(transactionRepository.existsByStatus(TransactionStatus.PENDING)).thenReturn(expected);
+
+        boolean inProgress = transactionService.isTransactionInProgress();
+
+        assertThat(inProgress).isEqualTo(expected);
     }
 
 }

--- a/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/wallet/resource/WalletResourceIntegrationTest.java
+++ b/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/wallet/resource/WalletResourceIntegrationTest.java
@@ -169,6 +169,22 @@ class WalletResourceIntegrationTest extends BaseIntegrationTest {
     }
 
     @Test
+    void shouldReturn409WhenTransactionIsInProgress() throws Exception {
+        Transaction transaction = new Transaction();
+        transaction.setStatus(TransactionStatus.PENDING);
+        transactionRepository.save(transaction);
+        Wallet oldWallet = new Wallet("123", "456", "789", Collections.emptyList(), 2);
+        oldWallet.setStatus(WalletStatus.ON_DUTY);
+        walletRepository.save(oldWallet);
+        List<String> adminEmails = List.of("dd@dd.pl", "ddd@dd.pl");
+        CreateWalletRequest request = new CreateWalletRequest(2, adminEmails);
+        mockMvc.perform(post("/wallet")
+                        .content(new ObjectMapper().writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
     void shouldReturn400WhenRecreatedWaletHasTheSameData() throws Exception {
         String publicKey = "0346b221a71369a6f70be9660ae560096396cf6813a051fcaf50a418d517007fcb";
         AdminUser admin1 = UserFactory.createAdminUser("admin1@test.pl");

--- a/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/wallet/resource/WalletResourceIntegrationTest.java
+++ b/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/wallet/resource/WalletResourceIntegrationTest.java
@@ -3,7 +3,9 @@ package pl.edu.pjatk.lnpayments.webservice.wallet.resource;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.bitcoinj.core.Coin;
+import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.kits.WalletAppKit;
+import org.bitcoinj.params.RegTestParams;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.lightningj.lnd.wrapper.SynchronousLndAPI;
@@ -15,30 +17,40 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 import pl.edu.pjatk.lnpayments.webservice.auth.repository.AdminUserRepository;
 import pl.edu.pjatk.lnpayments.webservice.common.entity.AdminUser;
 import pl.edu.pjatk.lnpayments.webservice.helper.config.BaseIntegrationTest;
 import pl.edu.pjatk.lnpayments.webservice.helper.config.IntegrationTestConfiguration;
 import pl.edu.pjatk.lnpayments.webservice.helper.factory.UserFactory;
+import pl.edu.pjatk.lnpayments.webservice.notification.model.Notification;
+import pl.edu.pjatk.lnpayments.webservice.notification.model.NotificationType;
+import pl.edu.pjatk.lnpayments.webservice.notification.repository.NotificationRepository;
+import pl.edu.pjatk.lnpayments.webservice.transaction.model.Transaction;
+import pl.edu.pjatk.lnpayments.webservice.transaction.model.TransactionStatus;
+import pl.edu.pjatk.lnpayments.webservice.transaction.repository.TransactionRepository;
 import pl.edu.pjatk.lnpayments.webservice.wallet.entity.Wallet;
+import pl.edu.pjatk.lnpayments.webservice.wallet.entity.WalletStatus;
 import pl.edu.pjatk.lnpayments.webservice.wallet.repository.WalletRepository;
 import pl.edu.pjatk.lnpayments.webservice.wallet.resource.dto.CreateWalletRequest;
 
 import java.util.Collections;
+import java.util.HexFormat;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ActiveProfiles("test")
 @AutoConfigureMockMvc(addFilters = false)
 @SpringBootTest(classes = IntegrationTestConfiguration.class)
+@TestPropertySource(properties = "app.scheduling.enable=false")
 class WalletResourceIntegrationTest extends BaseIntegrationTest {
 
     private final static String EMAIL = "test@test.pl";
@@ -58,9 +70,17 @@ class WalletResourceIntegrationTest extends BaseIntegrationTest {
     @Autowired
     private WalletAppKit walletAppKit;
 
+    @Autowired
+    private NotificationRepository notificationRepository;
+
+    @Autowired
+    private TransactionRepository transactionRepository;
+
     @AfterEach
     void tearDown() {
+        notificationRepository.deleteAll();
         adminUserRepository.deleteAll();
+        transactionRepository.deleteAll();
         walletRepository.deleteAll();
     }
 
@@ -90,12 +110,58 @@ class WalletResourceIntegrationTest extends BaseIntegrationTest {
         assertThat(wallets.get(0).getMinSignatures()).isEqualTo(1);
     }
 
-    @Test
-    void shouldReturn409IfWalletAlreadyExists() throws Exception {
-        Wallet wallet = new Wallet("123", "456", "789", Collections.emptyList(), 1);
-        walletRepository.save(wallet);
-        CreateWalletRequest request = new CreateWalletRequest(1, List.of(EMAIL));
 
+    @Test
+    void shouldRecreateWalletWhenWalletAlreadyExists() throws Exception {
+        String publicKey = "0346b221a71369a6f70be9660ae560096396cf6813a051fcaf50a418d517007fcb";
+        AdminUser admin1 = UserFactory.createAdminUser("admin1@test.pl");
+        admin1.setPublicKey(publicKey);
+        AdminUser admin2 = UserFactory.createAdminUser("admin2@test.pl");
+        admin2.setPublicKey(publicKey);
+        Wallet oldWallet = new Wallet("123", "456", "2N9fb1HjNWYs77MHhvnWGHunDeFwMMeYxo4", List.of(admin1, admin2), 2);
+        oldWallet.setStatus(WalletStatus.ON_DUTY);
+        walletRepository.save(oldWallet);
+        admin1.setWallet(oldWallet);
+        admin2.setWallet(oldWallet);
+        adminUserRepository.save(admin1);
+        adminUserRepository.save(admin2);
+        List<String> adminEmails = List.of(admin1.getEmail(), admin2.getEmail());
+        CreateWalletRequest request = new CreateWalletRequest(1, adminEmails);
+        NetworkParameters params = RegTestParams.get();
+        org.bitcoinj.core.Transaction transaction1 = new org.bitcoinj.core.Transaction(params, HexFormat.of().parseHex("01000000012a3c2133f9b678877ae4afd5a982bdc453d5e86749722fe189acd5a2c97660f300000000d9004730440220407e37b9e31d1200f2abe0e393338db0aa1bd21783ccc06f68aee92aae529a790220627b7052a9bc8dd4dc5c55e4f631a97296b3e1ddfe19fb2b5528cb0d130f0c260147304402200a505e3526df75a3addf672c366f79fe28b3f0220f063f78db8ae4a921d0e97a02207aefa698d8f1a984b93fff4480cd30b5e174832e3dab84365a4766615845c8580147522102ab7358f9fba8b2661dc6b489ced6cac0d620eb1de82100e6cf40c404ee44dc3a210346b221a71369a6f70be9660ae560096396cf6813a051fcaf50a418d517007fcb52aeffffffff026400000000000000160014a9619fc4a9c6d2d36eb6ace4d5bc9abdbebc8f5cc42200000000000017a914b41d8a3e10f6a407ae80ceea45a8eae867ac78598700000000"));
+        org.bitcoinj.wallet.Wallet walletMock = Mockito.mock(org.bitcoinj.wallet.Wallet.class);
+        when(walletAppKit.wallet()).thenReturn(walletMock);
+        when(walletAppKit.params()).thenReturn(params);
+        when(walletMock.getWatchedOutputs(true)).thenReturn(transaction1.getOutputs());
+        when(walletMock.getBalance(org.bitcoinj.wallet.Wallet.BalanceType.AVAILABLE)).thenReturn(Coin.valueOf(1000L));
+        when(walletMock.getBalance(org.bitcoinj.wallet.Wallet.BalanceType.ESTIMATED)).thenReturn(Coin.valueOf(0L));
+
+        mockMvc.perform(post("/wallet")
+                        .content(new ObjectMapper().writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isCreated());
+
+        Wallet wallet = walletRepository.findFirstByStatus(WalletStatus.IN_CREATION).orElseThrow();
+        assertThat(walletRepository.existsByStatus(WalletStatus.ON_DUTY)).isTrue();
+        assertThat(wallet.getAddress()).isEqualTo("2NGEpb541CnfpmA3LEWoehMNCnG94ybTR3F");
+        assertThat(wallet.getRedeemScript()).isEqualTo("51210346b221a71369a6f70be9660ae560096396cf6813a051fcaf50a418d517007fcb210346b221a71369a6f70be9660ae560096396cf6813a051fcaf50a418d517007fcb52ae");
+        assertThat(wallet.getScriptPubKey()).isEqualTo("a914fc375c082884b9d7575ac04102d11218406434d287");
+        assertThat(wallet.getUsers().size()).isEqualTo(2);
+        assertThat(wallet.getMinSignatures()).isEqualTo(1);
+        Transaction transaction = transactionRepository.findFirstByStatus(TransactionStatus.PENDING).orElseThrow();
+        assertThat(transaction.getNotifications()).hasSize(2);
+        assertThat(transaction.getNotifications()).extracting(Notification::getType).allMatch(s -> s == NotificationType.WALLET_RECREATION);
+    }
+
+    @Test
+    void shouldReturn409WhenWalletInCreationAlreadyExists() throws Exception {
+        Wallet oldWallet = new Wallet("123", "456", "789", Collections.emptyList(), 2);
+        oldWallet.setStatus(WalletStatus.ON_DUTY);
+        Wallet newWallet = new Wallet("123", "456", "789", Collections.emptyList(), 2);
+        newWallet.setStatus(WalletStatus.IN_CREATION);
+        walletRepository.saveAll(List.of(oldWallet, newWallet));
+        List<String> adminEmails = List.of("dd@dd.pl", "ddd@dd.pl");
+        CreateWalletRequest request = new CreateWalletRequest(2, adminEmails);
         mockMvc.perform(post("/wallet")
                         .content(new ObjectMapper().writeValueAsString(request))
                         .contentType(MediaType.APPLICATION_JSON))
@@ -103,9 +169,21 @@ class WalletResourceIntegrationTest extends BaseIntegrationTest {
     }
 
     @Test
-    void shouldReturn404WhenWrongNumberOfAdmins() throws Exception {
-        CreateWalletRequest request = new CreateWalletRequest(1, List.of(EMAIL));
-
+    void shouldReturn400WhenRecreatedWaletHasTheSameData() throws Exception {
+        String publicKey = "0346b221a71369a6f70be9660ae560096396cf6813a051fcaf50a418d517007fcb";
+        AdminUser admin1 = UserFactory.createAdminUser("admin1@test.pl");
+        admin1.setPublicKey(publicKey);
+        AdminUser admin2 = UserFactory.createAdminUser("admin2@test.pl");
+        admin2.setPublicKey(publicKey);
+        Wallet oldWallet = new Wallet("123", "456", "2N9fb1HjNWYs77MHhvnWGHunDeFwMMeYxo4", List.of(admin1, admin2), 2);
+        oldWallet.setStatus(WalletStatus.ON_DUTY);
+        walletRepository.save(oldWallet);
+        admin1.setWallet(oldWallet);
+        admin2.setWallet(oldWallet);
+        adminUserRepository.save(admin1);
+        adminUserRepository.save(admin2);
+        List<String> adminEmails = List.of(admin1.getEmail(), admin2.getEmail());
+        CreateWalletRequest request = new CreateWalletRequest(2, adminEmails);
         mockMvc.perform(post("/wallet")
                         .content(new ObjectMapper().writeValueAsString(request))
                         .contentType(MediaType.APPLICATION_JSON))
@@ -164,6 +242,7 @@ class WalletResourceIntegrationTest extends BaseIntegrationTest {
     @Test
     void shouldReturn200ForTransfer() throws Exception {
         Wallet wallet = new Wallet("123", "456", "789", Collections.emptyList(), 1);
+        wallet.setStatus(WalletStatus.ON_DUTY);
         walletRepository.save(wallet);
         WalletBalanceResponse balanceRequest = new WalletBalanceResponse();
         balanceRequest.setConfirmedBalance(2137L);
@@ -178,6 +257,7 @@ class WalletResourceIntegrationTest extends BaseIntegrationTest {
     @Test
     void shouldReturn200ForBalanceRequest() throws Exception {
         Wallet wallet = new Wallet("123", "456", "789", Collections.emptyList(), 1);
+        wallet.setStatus(WalletStatus.ON_DUTY);
         walletRepository.save(wallet);
         org.bitcoinj.wallet.Wallet walletMock = Mockito.mock(org.bitcoinj.wallet.Wallet.class);
         when(walletMock.getBalance(org.bitcoinj.wallet.Wallet.BalanceType.AVAILABLE)).thenReturn(Coin.valueOf(1000L));
@@ -214,6 +294,7 @@ class WalletResourceIntegrationTest extends BaseIntegrationTest {
     @Test
     void shouldReturn500WhenThereIsLightningException() throws Exception {
         Wallet wallet = new Wallet("123", "456", "789", Collections.emptyList(), 1);
+        wallet.setStatus(WalletStatus.ON_DUTY);
         walletRepository.save(wallet);
         when(lndAPI.channelBalance()).thenThrow(ValidationException.class);
 

--- a/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/wallet/scheduler/WalletActionsSchedulerIntegrationTest.java
+++ b/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/wallet/scheduler/WalletActionsSchedulerIntegrationTest.java
@@ -1,9 +1,18 @@
 package pl.edu.pjatk.lnpayments.webservice.wallet.scheduler;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import org.assertj.core.groups.Tuple;
 import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.lightningj.lnd.wrapper.*;
+import org.lightningj.lnd.wrapper.AsynchronousLndAPI;
+import org.lightningj.lnd.wrapper.SynchronousLndAPI;
 import org.lightningj.lnd.wrapper.message.*;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.SpyBean;
@@ -12,12 +21,14 @@ import org.springframework.test.context.TestPropertySource;
 import pl.edu.pjatk.lnpayments.webservice.helper.config.BaseIntegrationTest;
 import pl.edu.pjatk.lnpayments.webservice.helper.config.IntegrationTestConfiguration;
 import pl.edu.pjatk.lnpayments.webservice.wallet.entity.Wallet;
+import pl.edu.pjatk.lnpayments.webservice.wallet.entity.WalletStatus;
 import pl.edu.pjatk.lnpayments.webservice.wallet.repository.WalletRepository;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -43,9 +54,24 @@ class WalletActionsSchedulerIntegrationTest extends BaseIntegrationTest {
     @SpyBean
     private WalletActionsScheduler walletActionsScheduler;
 
+    private ListAppender<ILoggingEvent> logAppender;
+
+    @BeforeEach
+    void setUp() {
+        logAppender = new ListAppender<>();
+        logAppender.start();
+        ((Logger) LoggerFactory.getLogger(WalletActionsScheduler.class)).addAppender(logAppender);
+    }
+
+    @AfterEach
+    void tearDown() {
+        walletRepository.deleteAll();
+    }
+
     @Test
     void shouldPerformAutoTransfer() throws Exception {
         Wallet wallet = new Wallet("123", "456", "789", Collections.emptyList(), 1);
+        wallet.setStatus(WalletStatus.ON_DUTY);
         walletRepository.save(wallet);
         WalletBalanceResponse balanceRequest = new WalletBalanceResponse();
         balanceRequest.setConfirmedBalance(213700000L);
@@ -71,6 +97,37 @@ class WalletActionsSchedulerIntegrationTest extends BaseIntegrationTest {
     }
 
     @Test
+    void shouldNotPerformAutoTransferWhenWalletIsInCreation() throws Exception {
+        Wallet wallet = new Wallet("123", "456", "789", Collections.emptyList(), 1);
+        wallet.setStatus(WalletStatus.IN_CREATION);
+        walletRepository.save(wallet);
+        WalletBalanceResponse balanceRequest = new WalletBalanceResponse();
+        balanceRequest.setConfirmedBalance(213700000L);
+        SendCoinsResponse sendCoinsResponse = new SendCoinsResponse();
+        sendCoinsResponse.setTxid("tx");
+        when(lndAPI.walletBalance()).thenReturn(balanceRequest);
+        when(lndAPI.sendCoins(any())).thenReturn(sendCoinsResponse);
+        ChannelBalanceResponse balanceResponse = new ChannelBalanceResponse();
+        balanceResponse.setBalance(1000L);
+        Channel channel1 = new Channel();
+        channel1.setChannelPoint("channel1:1");
+        channel1.setActive(true);
+        channel1.setChanId(1);
+        ListChannelsResponse listChannelsResponse = new ListChannelsResponse();
+        listChannelsResponse.setChannels(List.of(channel1));
+        when(lndAPI.channelBalance()).thenReturn(balanceResponse);
+        when(lndAPI.listChannels(any())).thenReturn(listChannelsResponse);
+
+        Awaitility.await().atMost(1, TimeUnit.SECONDS).untilAsserted(() -> {
+            verify(walletActionsScheduler, atLeastOnce()).scheduleAutoTransfer();
+            verify(lndAPI, never()).sendCoins(any());
+            assertThat(logAppender.list)
+                    .extracting(ILoggingEvent::getMessage, ILoggingEvent::getLevel)
+                    .contains(Tuple.tuple("Unable to transfer funds with scheduler: {}", Level.ERROR));
+        });
+    }
+
+    @Test
     void shouldInvokeSchedulerButNotTransferFundsWhenNoWallet() {
         Awaitility.await().atMost(1, TimeUnit.SECONDS).untilAsserted(() -> {
             verify(walletActionsScheduler, atLeastOnce()).scheduleAutoTransfer();
@@ -90,6 +147,7 @@ class WalletActionsSchedulerIntegrationTest extends BaseIntegrationTest {
     @Test
     void shouldCloseChannelsWhenThresholdExceeded() throws Exception {
         Wallet wallet = new Wallet("123", "456", "789", Collections.emptyList(), 1);
+        wallet.setStatus(WalletStatus.ON_DUTY);
         walletRepository.save(wallet);
         WalletBalanceResponse balanceRequest = new WalletBalanceResponse();
         balanceRequest.setConfirmedBalance(2137L);

--- a/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/wallet/service/BitcoinServiceTest.java
+++ b/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/wallet/service/BitcoinServiceTest.java
@@ -106,6 +106,28 @@ class BitcoinServiceTest {
     }
 
     @Test
+    void shouldCreateSweepTransaction() {
+        RegTestParams params = RegTestParams.get();
+        org.bitcoinj.core.Transaction transaction1 = new org.bitcoinj.core.Transaction(params, HexFormat.of().parseHex("01000000012a3c2133f9b678877ae4afd5a982bdc453d5e86749722fe189acd5a2c97660f300000000d9004730440220407e37b9e31d1200f2abe0e393338db0aa1bd21783ccc06f68aee92aae529a790220627b7052a9bc8dd4dc5c55e4f631a97296b3e1ddfe19fb2b5528cb0d130f0c260147304402200a505e3526df75a3addf672c366f79fe28b3f0220f063f78db8ae4a921d0e97a02207aefa698d8f1a984b93fff4480cd30b5e174832e3dab84365a4766615845c8580147522102ab7358f9fba8b2661dc6b489ced6cac0d620eb1de82100e6cf40c404ee44dc3a210346b221a71369a6f70be9660ae560096396cf6813a051fcaf50a418d517007fcb52aeffffffff026400000000000000160014a9619fc4a9c6d2d36eb6ace4d5bc9abdbebc8f5cc42200000000000017a914b41d8a3e10f6a407ae80ceea45a8eae867ac78598700000000"));
+        String destinationAddress = "2N61hyQz11Y8kJ3tjh42w1QAAgmJFdanYEv";
+        String sourceAddress = "2N9fb1HjNWYs77MHhvnWGHunDeFwMMeYxo4";
+        org.bitcoinj.wallet.Wallet walletMock = Mockito.mock(org.bitcoinj.wallet.Wallet.class);
+        when(walletAppKit.wallet()).thenReturn(walletMock);
+        when(walletAppKit.params()).thenReturn(params);
+        when(walletMock.getWatchedOutputs(true)).thenReturn(transaction1.getOutputs());
+
+        Transaction transaction = bitcoinService.createTransaction(sourceAddress, destinationAddress);
+
+        assertThat(transaction.getStatus()).isEqualTo(TransactionStatus.PENDING);
+        //Can't be checked really, because it works only for transactions created by
+        assertThat(transaction.getFee()).isEqualTo(1000L);
+        assertThat(transaction.getInputValue()).isEqualTo(7900L);
+        assertThat(transaction.getSourceAddress()).isEqualTo(sourceAddress);
+        assertThat(transaction.getTargetAddress()).isEqualTo(destinationAddress);
+        assertThat(transaction.getRawTransaction()).isEqualTo("0100000001102b444becb78e1fbb79d7fda0a42f78594ee5fd86a8ddf753a65ce5012787350100000000ffffffff01dc1e00000000000017a9148c0b2c246ce6738f00f5dd47948966f791042ad88700000000");
+    }
+
+    @Test
     void shouldThrowExceptionWhenInvalidInputValueProvided() {
         RegTestParams params = RegTestParams.get();
         org.bitcoinj.core.Transaction transaction1 = new org.bitcoinj.core.Transaction(params, HexFormat.of().parseHex("01000000012a3c2133f9b678877ae4afd5a982bdc453d5e86749722fe189acd5a2c97660f300000000d9004730440220407e37b9e31d1200f2abe0e393338db0aa1bd21783ccc06f68aee92aae529a790220627b7052a9bc8dd4dc5c55e4f631a97296b3e1ddfe19fb2b5528cb0d130f0c260147304402200a505e3526df75a3addf672c366f79fe28b3f0220f063f78db8ae4a921d0e97a02207aefa698d8f1a984b93fff4480cd30b5e174832e3dab84365a4766615845c8580147522102ab7358f9fba8b2661dc6b489ced6cac0d620eb1de82100e6cf40c404ee44dc3a210346b221a71369a6f70be9660ae560096396cf6813a051fcaf50a418d517007fcb52aeffffffff026400000000000000160014a9619fc4a9c6d2d36eb6ace4d5bc9abdbebc8f5cc42200000000000017a914b41d8a3e10f6a407ae80ceea45a8eae867ac78598700000000"));

--- a/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/wallet/service/WalletDataServiceTest.java
+++ b/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/wallet/service/WalletDataServiceTest.java
@@ -1,0 +1,102 @@
+package pl.edu.pjatk.lnpayments.webservice.wallet.service;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import pl.edu.pjatk.lnpayments.webservice.common.exception.NotFoundException;
+import pl.edu.pjatk.lnpayments.webservice.wallet.entity.Wallet;
+import pl.edu.pjatk.lnpayments.webservice.wallet.entity.WalletStatus;
+import pl.edu.pjatk.lnpayments.webservice.wallet.repository.WalletRepository;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class WalletDataServiceTest {
+
+    @Mock
+    private WalletRepository walletRepository;
+
+    @InjectMocks
+    private WalletDataService walletDataService;
+
+    @Test
+    void shouldThrowNotFoundExceptionWhenWalletDoesNotExist() {
+        when(walletRepository.findFirstByStatus(WalletStatus.ON_DUTY)).thenReturn(Optional.empty());
+
+        assertThatExceptionOfType(NotFoundException.class)
+                .isThrownBy(() -> walletDataService.getActiveWallet());
+    }
+
+    @Test
+    void shouldReturnActiveWallet() {
+        Wallet wallet = Wallet.builder().address("2137").build();
+        when(walletRepository.findFirstByStatus(WalletStatus.ON_DUTY)).thenReturn(Optional.of(wallet));
+
+        Wallet actual = walletDataService.getActiveWallet();
+
+        assertThat(actual).isEqualTo(wallet);
+    }
+
+    @Test
+    void shouldThrowNotFoundExceptionWhenWalletInCreationDoesNotExist() {
+        when(walletRepository.findFirstByStatus(WalletStatus.IN_CREATION)).thenReturn(Optional.empty());
+
+        assertThatExceptionOfType(NotFoundException.class)
+                .isThrownBy(() -> walletDataService.getWalletInCreation());
+    }
+
+    @Test
+    void shouldReturnWalletInCreation() {
+        Wallet wallet = Wallet.builder().address("2137").build();
+        when(walletRepository.findFirstByStatus(WalletStatus.IN_CREATION)).thenReturn(Optional.of(wallet));
+
+        Wallet actual = walletDataService.getWalletInCreation();
+
+        assertThat(actual).isEqualTo(wallet);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void shouldReturnProperValueAboutActiveWalletExistence(boolean exists) {
+        when(walletRepository.existsByStatus(WalletStatus.ON_DUTY)).thenReturn(exists);
+
+        boolean actual = walletDataService.existsActive();
+
+        assertThat(actual).isEqualTo(exists);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void shouldReturnProperValueAboutWalletInCreationExistence(boolean exists) {
+        when(walletRepository.existsByStatus(WalletStatus.IN_CREATION)).thenReturn(exists);
+
+        boolean actual = walletDataService.existInCreation();
+
+        assertThat(actual).isEqualTo(exists);
+    }
+
+    @Test
+    void shouldCallDeleteInRepositoryWhenDeletingWalletInCreation() {
+        walletDataService.deleteCreatingWallet();
+
+        verify(walletRepository).deleteByStatus(WalletStatus.IN_CREATION);
+    }
+
+    @Test
+    void shouldCallRepositoryWhileSavingWallet() {
+        Wallet wallet = Wallet.builder().address("2137").build();
+        walletDataService.save(wallet);
+
+        verify(walletRepository).save(wallet);
+    }
+
+}

--- a/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/wallet/service/WalletServiceTest.java
+++ b/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/wallet/service/WalletServiceTest.java
@@ -200,7 +200,25 @@ class WalletServiceTest {
         when(walletDataService.existInCreation()).thenReturn(true);
 
         assertThatExceptionOfType(ValidationException.class)
-                .isThrownBy(() -> walletService.createWallet(adminEmails, 2));
+                .isThrownBy(() -> walletService.createWallet(adminEmails, 2))
+                .withMessage("There is already a wallet in creation process");
+        verify(walletDataService, never()).save(any());
+        verify(transactionService, never()).createTransaction(anyString());
+    }
+
+    @Test
+    void shouldThrowExceptionWhenTransactionIsPending() {
+        AdminUser admin1 = UserFactory.createAdminUser("admin1@test.pl");
+        AdminUser admin2 = UserFactory.createAdminUser("admin2@test.pl");
+        List<String> adminEmails = List.of(admin1.getEmail(), admin2.getEmail());
+        when(walletDataService.existsActive()).thenReturn(true);
+        when(walletDataService.existInCreation()).thenReturn(false);
+        when(transactionService.isTransactionInProgress()).thenReturn(true);
+
+        assertThatExceptionOfType(ValidationException.class)
+                .isThrownBy(() -> walletService.createWallet(adminEmails, 1))
+                .withMessage("There is already a transaction in progress");
+
         verify(walletDataService, never()).save(any());
         verify(transactionService, never()).createTransaction(anyString());
     }

--- a/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/wallet/service/WalletServiceTest.java
+++ b/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/wallet/service/WalletServiceTest.java
@@ -19,26 +19,23 @@ import pl.edu.pjatk.lnpayments.webservice.admin.converter.AdminConverter;
 import pl.edu.pjatk.lnpayments.webservice.admin.service.AdminService;
 import pl.edu.pjatk.lnpayments.webservice.common.entity.AdminUser;
 import pl.edu.pjatk.lnpayments.webservice.common.exception.InconsistentDataException;
-import pl.edu.pjatk.lnpayments.webservice.common.exception.NotFoundException;
 import pl.edu.pjatk.lnpayments.webservice.helper.factory.UserFactory;
+import pl.edu.pjatk.lnpayments.webservice.transaction.service.TransactionService;
 import pl.edu.pjatk.lnpayments.webservice.wallet.entity.Wallet;
 import pl.edu.pjatk.lnpayments.webservice.wallet.entity.WalletStatus;
-import pl.edu.pjatk.lnpayments.webservice.wallet.repository.WalletRepository;
 import pl.edu.pjatk.lnpayments.webservice.wallet.resource.dto.BitcoinWalletBalance;
 import pl.edu.pjatk.lnpayments.webservice.wallet.resource.dto.ChannelsBalance;
 import pl.edu.pjatk.lnpayments.webservice.wallet.resource.dto.LightningWalletBalance;
 import pl.edu.pjatk.lnpayments.webservice.wallet.resource.dto.WalletDetails;
 
 import javax.validation.ValidationException;
-import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class WalletServiceTest {
@@ -50,7 +47,7 @@ class WalletServiceTest {
     private AdminService adminService;
 
     @Mock
-    private WalletRepository walletRepository;
+    private WalletDataService walletDataService;
 
     @Mock
     private LightningWalletService lightningWalletService;
@@ -60,6 +57,9 @@ class WalletServiceTest {
 
     @Mock
     private AdminConverter adminConverter;
+
+    @Mock
+    private TransactionService transactionService;
 
     @InjectMocks
     private WalletService walletService;
@@ -80,16 +80,16 @@ class WalletServiceTest {
         List<String> adminEmails = List.of(admin1.getEmail(), admin2.getEmail());
         List<AdminUser> adminUsers = List.of(admin1, admin2);
         Wallet wallet = new Wallet("123", "456", "789", adminUsers, 2);
-        when(walletRepository.existsByStatus(any())).thenReturn(false);
+        when(walletDataService.existsActive()).thenReturn(false);
         when(adminService.findAllWithKeys(adminEmails)).thenReturn(adminUsers);
         when(bitcoinService.createWallet(adminUsers, 2)).thenReturn(wallet);
 
         walletService.createWallet(adminEmails, 2);
 
-        verify(walletRepository).existsByStatus(any());
         verify(bitcoinService).createWallet(adminUsers, 2);
         ArgumentCaptor<Wallet> captor = ArgumentCaptor.forClass(Wallet.class);
-        verify(walletRepository).save(captor.capture());
+        verify(walletDataService).existsActive();
+        verify(walletDataService).save(captor.capture());
         Wallet savedWallet = captor.getValue();
         assertThat(savedWallet.getAddress()).isEqualTo(wallet.getAddress());
         assertThat(savedWallet.getMinSignatures()).isEqualTo(wallet.getMinSignatures());
@@ -99,18 +99,39 @@ class WalletServiceTest {
     }
 
     @Test
-    void shouldThrowExceptionWhenWalletAlreadyExists() {
-        when(walletRepository.existsByStatus(any())).thenReturn(true);
+    void shouldRecreateWalletWhenActiveAlreadyExists() {
+        AdminUser admin1 = UserFactory.createAdminUser("admin1@test.pl");
+        AdminUser admin2 = UserFactory.createAdminUser("admin2@test.pl");
+        List<String> adminEmails = List.of(admin1.getEmail(), admin2.getEmail());
+        List<AdminUser> adminUsers = List.of(admin1, admin2);
+        Wallet oldWallet = new Wallet("123", "456", "7189", adminUsers, 1);
+        Wallet wallet = new Wallet("123", "456", "789", adminUsers, 2);
+        when(walletDataService.existsActive()).thenReturn(true);
+        when(walletDataService.existInCreation()).thenReturn(false);
+        when(walletDataService.getActiveWallet()).thenReturn(oldWallet);
+        when(walletDataService.save(wallet)).thenReturn(wallet);
+        when(adminService.findAllWithKeys(adminEmails)).thenReturn(adminUsers);
+        when(bitcoinService.createWallet(adminUsers, 2)).thenReturn(wallet);
 
-        assertThatExceptionOfType(ValidationException.class)
-                .isThrownBy(() -> walletService.createWallet(Collections.emptyList(), 2))
-                .withMessage("Wallet already exists!");
+        walletService.createWallet(adminEmails, 2);
+
+        verify(transactionService).createTransaction(wallet.getAddress());
+        verify(bitcoinService).createWallet(adminUsers, 2);
+        ArgumentCaptor<Wallet> captor = ArgumentCaptor.forClass(Wallet.class);
+        verify(walletDataService).existsActive();
+        verify(walletDataService).save(captor.capture());
+        Wallet savedWallet = captor.getValue();
+        assertThat(savedWallet.getAddress()).isEqualTo(wallet.getAddress());
+        assertThat(savedWallet.getMinSignatures()).isEqualTo(wallet.getMinSignatures());
+        assertThat(savedWallet.getRedeemScript()).isEqualTo(wallet.getRedeemScript());
+        assertThat(savedWallet.getScriptPubKey()).isEqualTo(wallet.getScriptPubKey());
+        assertThat(savedWallet.getUsers()).isEqualTo(wallet.getUsers());
     }
 
     @Test
     void shouldThrowExceptionWhenMoreRequiredSignaturesThanEmails() {
         List<String> adminEmails = List.of("asd@asd.pl", "dsa@dsa.lp");
-        when(walletRepository.existsByStatus(any())).thenReturn(false);
+        when(walletDataService.existsActive()).thenReturn(false);
 
         assertThatExceptionOfType(InconsistentDataException.class)
                 .isThrownBy(() -> walletService.createWallet(adminEmails, 3))
@@ -120,7 +141,7 @@ class WalletServiceTest {
     @Test
     void shouldTransferFundsToWalletAddressAndLogMessage() {
         Wallet wallet = Wallet.builder().address("2137").build();
-        when(walletRepository.findFirstByStatus(WalletStatus.ON_DUTY)).thenReturn(Optional.of(wallet));
+        when(walletDataService.getActiveWallet()).thenReturn(wallet);
 
         walletService.transferToWallet();
 
@@ -128,6 +149,18 @@ class WalletServiceTest {
         assertThat(logAppender.list)
                 .extracting(ILoggingEvent::getMessage, ILoggingEvent::getLevel)
                 .contains(Tuple.tuple("Funds were transferred in tx: {}", Level.INFO));
+    }
+
+    @Test
+    void shouldNotTransferWhenWalletIsInCreation() {
+        when(walletDataService.existInCreation()).thenReturn(true);
+
+        assertThatExceptionOfType(ValidationException.class)
+                .isThrownBy(() -> walletService.transferToWallet())
+                .withMessage("When wallet is in creation, transfer is unavailable");
+
+        verify(lightningWalletService, never()).transfer(anyString());
+        assertThat(logAppender.list).isEmpty();
     }
 
     @ParameterizedTest
@@ -144,7 +177,7 @@ class WalletServiceTest {
         ChannelsBalance channelsBalance = ChannelsBalance.builder().openedChannels(1).totalBalance(100L).autoChannelCloseLimit(100L).build();
         LightningWalletBalance lightningWalletBalance = LightningWalletBalance.builder().availableBalance(100L).unconfirmedBalance(100L).autoTransferLimit(100L).build();
         Wallet wallet = Wallet.builder().address("2137").build();
-        when(walletRepository.findFirstByStatus(WalletStatus.ON_DUTY)).thenReturn(Optional.of(wallet));
+        when(walletDataService.getActiveWallet()).thenReturn(wallet);
         when(lightningWalletService.getBalance()).thenReturn(lightningWalletBalance);
         when(bitcoinService.getBalance()).thenReturn(bitcoinWalletBalance);
         when(channelService.getChannelsBalance()).thenReturn(channelsBalance);
@@ -157,30 +190,59 @@ class WalletServiceTest {
         assertThat(details.getLightningWalletBalance()).isEqualTo(lightningWalletBalance);
     }
 
-    @Test
-    void shouldThrowNotFoundExceptionWhenWalletDoesNotExist() {
-        when(walletRepository.findFirstByStatus(WalletStatus.ON_DUTY)).thenReturn(Optional.empty());
 
-        assertThatExceptionOfType(NotFoundException.class)
-                .isThrownBy(() -> walletService.getDetails());
+    @Test
+    void shouldThrowExceptionWhenWalletInCreationAlreadyExists() {
+        AdminUser admin1 = UserFactory.createAdminUser("admin1@test.pl");
+        AdminUser admin2 = UserFactory.createAdminUser("admin2@test.pl");
+        List<String> adminEmails = List.of(admin1.getEmail(), admin2.getEmail());
+        when(walletDataService.existsActive()).thenReturn(true);
+        when(walletDataService.existInCreation()).thenReturn(true);
+
+        assertThatExceptionOfType(ValidationException.class)
+                .isThrownBy(() -> walletService.createWallet(adminEmails, 2));
+        verify(walletDataService, never()).save(any());
+        verify(transactionService, never()).createTransaction(anyString());
     }
 
     @Test
-    void shouldReturnActiveWallet() {
-        Wallet wallet = Wallet.builder().address("2137").build();
-        when(walletRepository.findFirstByStatus(WalletStatus.ON_DUTY)).thenReturn(Optional.of(wallet));
+    void shouldThrowExceptionWhenTriedToRecreateWithSameData() {
+        AdminUser admin1 = UserFactory.createAdminUser("admin1@test.pl");
+        AdminUser admin2 = UserFactory.createAdminUser("admin2@test.pl");
+        List<String> adminEmails = List.of(admin1.getEmail(), admin2.getEmail());
+        List<AdminUser> adminUsers = List.of(admin1, admin2);
+        Wallet wallet = new Wallet("123", "456", "789", adminUsers, 2);
+        when(walletDataService.existsActive()).thenReturn(true);
+        when(walletDataService.existInCreation()).thenReturn(false);
+        when(walletDataService.getActiveWallet()).thenReturn(wallet);
+        when(adminService.findAllWithKeys(adminEmails)).thenReturn(adminUsers);
 
-        Wallet actual = walletService.getActiveWallet();
-
-        assertThat(actual).isEqualTo(wallet);
+        assertThatExceptionOfType(InconsistentDataException.class)
+                .isThrownBy(() -> walletService.createWallet(adminEmails, 2));
+        verify(walletDataService, never()).save(any());
+        verify(transactionService, never()).createTransaction(anyString());
     }
 
     @Test
-    void shouldThrowExceptionWhenWalletDoesNotExist() {
-        when(walletRepository.findFirstByStatus(WalletStatus.ON_DUTY)).thenReturn(Optional.empty());
+    void shouldSwapWallets() {
+        Wallet oldWallet = new Wallet("123", "456", "7189", null, 1);
+        oldWallet.setStatus(WalletStatus.ON_DUTY);
+        Wallet wallet = new Wallet("123", "456", "789", null, 2);
+        wallet.setStatus(WalletStatus.IN_CREATION);
+        when(walletDataService.getActiveWallet()).thenReturn(oldWallet);
+        when(walletDataService.getWalletInCreation()).thenReturn(wallet);
 
-        assertThatExceptionOfType(NotFoundException.class)
-                .isThrownBy(() -> walletService.getActiveWallet());
+        walletService.swapWallets();
+
+        assertThat(oldWallet.getStatus()).isEqualTo(WalletStatus.REMOVED);
+        assertThat(wallet.getStatus()).isEqualTo(WalletStatus.ON_DUTY);
+    }
+
+    @Test
+    void shouldInvokeServiceWhenDeletingWallet() {
+        walletDataService.deleteCreatingWallet();
+
+        verify(walletDataService).deleteCreatingWallet();
     }
 
 }


### PR DESCRIPTION
Link to the Jira issue
https://candybear.atlassian.net/browse/LP-161

### Description

I've implemented recreation flow. I used POST /wallet endpoint for that. If wallet already exists, it will proceed with recreation flow. Solution is not perfect, some code should be extracted with Template design pattern for example, but we have no time to make it better. 

### How did I test it

Unit and integration tests. We will make manual tests when front and mobileapp are done. Testing entire flow with postman is cumbersome.
