### PR TITLE
LP-177 Add total income data to balance endpoint

### DIFF
--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/payment/facade/PaymentFacade.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/payment/facade/PaymentFacade.java
@@ -114,6 +114,7 @@ public class PaymentFacade {
     public Map<Temporal, Long> aggregateTotalIncomeData() {
         return paymentDataService.findAll()
                 .stream()
+                .filter(payment -> payment.getStatus() == PaymentStatus.COMPLETE)
                 .sorted(Comparator.comparing(Payment::getDate))
                 .collect(Collectors.groupingBy(payment ->
                         YearMonth.from(LocalDate.ofInstant(payment.getDate(), ZoneId.systemDefault())),

--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/payment/service/PaymentDataService.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/payment/service/PaymentDataService.java
@@ -43,4 +43,8 @@ public class PaymentDataService {
     public Page<Payment> findAll(Pageable pageable) {
         return paymentRepository.findAll(pageable);
     }
+
+    public Collection<Payment> findAll() {
+        return paymentRepository.findAll();
+    }
 }

--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/wallet/resource/dto/WalletDetails.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/wallet/resource/dto/WalletDetails.java
@@ -4,7 +4,9 @@ import lombok.Builder;
 import lombok.Getter;
 import pl.edu.pjatk.lnpayments.webservice.admin.resource.dto.AdminResponse;
 
+import java.time.temporal.Temporal;
 import java.util.List;
+import java.util.Map;
 
 @Getter
 @Builder
@@ -15,4 +17,5 @@ public class WalletDetails {
     private final ChannelsBalance channelsBalance;
     private final LightningWalletBalance lightningWalletBalance;
     private final BitcoinWalletBalance bitcoinWalletBalance;
+    private final Map<Temporal, Long> totalIncomeData;
 }

--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/wallet/service/WalletService.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/wallet/service/WalletService.java
@@ -7,6 +7,7 @@ import pl.edu.pjatk.lnpayments.webservice.admin.converter.AdminConverter;
 import pl.edu.pjatk.lnpayments.webservice.admin.service.AdminService;
 import pl.edu.pjatk.lnpayments.webservice.common.entity.AdminUser;
 import pl.edu.pjatk.lnpayments.webservice.common.exception.InconsistentDataException;
+import pl.edu.pjatk.lnpayments.webservice.payment.facade.PaymentFacade;
 import pl.edu.pjatk.lnpayments.webservice.transaction.service.TransactionService;
 import pl.edu.pjatk.lnpayments.webservice.wallet.entity.Wallet;
 import pl.edu.pjatk.lnpayments.webservice.wallet.entity.WalletStatus;
@@ -27,6 +28,7 @@ public class WalletService {
     private final AdminConverter adminConverter;
     private final TransactionService transactionService;
     private final WalletDataService walletDataService;
+    private final PaymentFacade paymentFacade;
 
     @Autowired
     public WalletService(BitcoinService bitcoinService,
@@ -35,7 +37,7 @@ public class WalletService {
                          ChannelService channelService,
                          AdminConverter adminConverter,
                          TransactionService transactionService,
-                         WalletDataService walletDataService) {
+                         WalletDataService walletDataService, PaymentFacade paymentFacade) {
         this.bitcoinService = bitcoinService;
         this.adminService = adminService;
         this.lightningWalletService = lightningWalletService;
@@ -43,6 +45,7 @@ public class WalletService {
         this.adminConverter = adminConverter;
         this.transactionService = transactionService;
         this.walletDataService = walletDataService;
+        this.paymentFacade = paymentFacade;
     }
 
     @Transactional
@@ -75,6 +78,7 @@ public class WalletService {
                 .bitcoinWalletBalance(bitcoinService.getBalance())
                 .channelsBalance(channelService.getChannelsBalance())
                 .lightningWalletBalance(lightningWalletService.getBalance())
+                .totalIncomeData(paymentFacade.aggregateTotalIncomeData())
                 .build();
     }
 

--- a/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/payment/service/PaymentDataServiceTest.java
+++ b/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/payment/service/PaymentDataServiceTest.java
@@ -96,7 +96,7 @@ class PaymentDataServiceTest {
     }
 
     @Test
-    void shouldReturnAllPayments() {
+    void shouldReturnAllPaymentsInPage() {
         List<Payment> payments = List.of(
                 new Payment("123", 1, 1, 123, PaymentStatus.PENDING, null),
                 new Payment("456", 3, 2, 126, PaymentStatus.COMPLETE, null),
@@ -116,5 +116,19 @@ class PaymentDataServiceTest {
         Page<Payment> response = paymentDataService.findAll(PageRequest.ofSize(3));
 
         assertThat(response).isEmpty();
+    }
+
+    @Test
+    void shouldReturnAllPayments() {
+        List<Payment> payments = List.of(
+                new Payment("123", 1, 1, 123, PaymentStatus.PENDING, null),
+                new Payment("456", 3, 2, 126, PaymentStatus.COMPLETE, null),
+                new Payment("789", 4, 3, 129, PaymentStatus.CANCELLED, null)
+        );
+        when(paymentRepository.findAll()).thenReturn(payments);
+
+        Collection<Payment> response = paymentDataService.findAll();
+
+        assertThat(response).hasSize(3);
     }
 }

--- a/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/wallet/resource/WalletResourceIntegrationTest.java
+++ b/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/wallet/resource/WalletResourceIntegrationTest.java
@@ -27,6 +27,9 @@ import pl.edu.pjatk.lnpayments.webservice.helper.factory.UserFactory;
 import pl.edu.pjatk.lnpayments.webservice.notification.model.Notification;
 import pl.edu.pjatk.lnpayments.webservice.notification.model.NotificationType;
 import pl.edu.pjatk.lnpayments.webservice.notification.repository.NotificationRepository;
+import pl.edu.pjatk.lnpayments.webservice.payment.model.entity.Payment;
+import pl.edu.pjatk.lnpayments.webservice.payment.model.entity.PaymentStatus;
+import pl.edu.pjatk.lnpayments.webservice.payment.repository.PaymentRepository;
 import pl.edu.pjatk.lnpayments.webservice.transaction.model.Transaction;
 import pl.edu.pjatk.lnpayments.webservice.transaction.model.TransactionStatus;
 import pl.edu.pjatk.lnpayments.webservice.transaction.repository.TransactionRepository;
@@ -35,6 +38,7 @@ import pl.edu.pjatk.lnpayments.webservice.wallet.entity.WalletStatus;
 import pl.edu.pjatk.lnpayments.webservice.wallet.repository.WalletRepository;
 import pl.edu.pjatk.lnpayments.webservice.wallet.resource.dto.CreateWalletRequest;
 
+import java.time.Instant;
 import java.util.Collections;
 import java.util.HexFormat;
 import java.util.List;
@@ -69,6 +73,9 @@ class WalletResourceIntegrationTest extends BaseIntegrationTest {
 
     @Autowired
     private WalletAppKit walletAppKit;
+
+    @Autowired
+    private PaymentRepository paymentRepository;
 
     @Autowired
     private NotificationRepository notificationRepository;
@@ -293,6 +300,14 @@ class WalletResourceIntegrationTest extends BaseIntegrationTest {
         walletBalanceResponse.setUnconfirmedBalance(100L);
         walletBalanceResponse.setConfirmedBalance(1000L);
         when(lndAPI.walletBalance()).thenReturn(walletBalanceResponse);
+        Instant date = Instant.ofEpochSecond(1656272934);
+        Payment payment1 = new Payment("123", 1, 1, 123, PaymentStatus.COMPLETE, null);
+        payment1.setDate(date);
+        Payment payment2 = new Payment("125", 1, 2, 123, PaymentStatus.COMPLETE, null);
+        payment2.setDate(date.minusSeconds(3_000_000));
+        Payment payment3 = new Payment("124", 1, 3, 123, PaymentStatus.COMPLETE, null);
+        payment3.setDate(date.minusSeconds(6_000_000));
+        paymentRepository.saveAll(List.of(payment1, payment2, payment3));
 
         String jsonContent = getJsonResponse("integration/wallet/response/balance-GET.json");
 

--- a/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/wallet/service/WalletServiceTest.java
+++ b/webservice/src/test/java/pl/edu/pjatk/lnpayments/webservice/wallet/service/WalletServiceTest.java
@@ -20,6 +20,7 @@ import pl.edu.pjatk.lnpayments.webservice.admin.service.AdminService;
 import pl.edu.pjatk.lnpayments.webservice.common.entity.AdminUser;
 import pl.edu.pjatk.lnpayments.webservice.common.exception.InconsistentDataException;
 import pl.edu.pjatk.lnpayments.webservice.helper.factory.UserFactory;
+import pl.edu.pjatk.lnpayments.webservice.payment.facade.PaymentFacade;
 import pl.edu.pjatk.lnpayments.webservice.transaction.service.TransactionService;
 import pl.edu.pjatk.lnpayments.webservice.wallet.entity.Wallet;
 import pl.edu.pjatk.lnpayments.webservice.wallet.entity.WalletStatus;
@@ -29,7 +30,10 @@ import pl.edu.pjatk.lnpayments.webservice.wallet.resource.dto.LightningWalletBal
 import pl.edu.pjatk.lnpayments.webservice.wallet.resource.dto.WalletDetails;
 
 import javax.validation.ValidationException;
+import java.time.LocalDate;
+import java.time.temporal.Temporal;
 import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -60,6 +64,9 @@ class WalletServiceTest {
 
     @Mock
     private TransactionService transactionService;
+
+    @Mock
+    private PaymentFacade paymentFacade;
 
     @InjectMocks
     private WalletService walletService;
@@ -173,6 +180,7 @@ class WalletServiceTest {
 
     @Test
     void shouldReturnWalletBalance() {
+        Map<Temporal, Long> balanceHistoricData = Map.of(LocalDate.now(), 12L);
         BitcoinWalletBalance bitcoinWalletBalance = BitcoinWalletBalance.builder().availableBalance(100L).unconfirmedBalance(100L).build();
         ChannelsBalance channelsBalance = ChannelsBalance.builder().openedChannels(1).totalBalance(100L).autoChannelCloseLimit(100L).build();
         LightningWalletBalance lightningWalletBalance = LightningWalletBalance.builder().availableBalance(100L).unconfirmedBalance(100L).autoTransferLimit(100L).build();
@@ -181,6 +189,7 @@ class WalletServiceTest {
         when(lightningWalletService.getBalance()).thenReturn(lightningWalletBalance);
         when(bitcoinService.getBalance()).thenReturn(bitcoinWalletBalance);
         when(channelService.getChannelsBalance()).thenReturn(channelsBalance);
+        when(paymentFacade.aggregateTotalIncomeData()).thenReturn(balanceHistoricData);
 
         WalletDetails details = walletService.getDetails();
 
@@ -188,6 +197,7 @@ class WalletServiceTest {
         assertThat(details.getChannelsBalance()).isEqualTo(channelsBalance);
         assertThat(details.getBitcoinWalletBalance()).isEqualTo(bitcoinWalletBalance);
         assertThat(details.getLightningWalletBalance()).isEqualTo(lightningWalletBalance);
+        assertThat(details.getTotalIncomeData()).isEqualTo(balanceHistoricData);
     }
 
 

--- a/webservice/src/test/resources/integration/wallet/response/balance-GET.json
+++ b/webservice/src/test/resources/integration/wallet/response/balance-GET.json
@@ -15,5 +15,10 @@
     "availableBalance": 1000,
     "unconfirmedBalance": 100,
     "currentReferenceFee": 1000
+  },
+  "totalIncomeData": {
+    "2022-04": 3,
+    "2022-05": 2,
+    "2022-06": 1
   }
 }


### PR DESCRIPTION
Link to the Jira issue
https://candybear.atlassian.net/browse/LP-177

### Description

Added historic aggregated data to wallet response. Data is grouped by month and year.
![image](https://user-images.githubusercontent.com/27137794/175831758-5c402474-4781-4d77-8d97-0cd525939445.png)

### How did I test it

Unit and integration tests.
