### PR TITLE
LP-196 Enable basic request logging

### DIFF
--- a/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/common/config/LoggerConfig.java
+++ b/webservice/src/main/java/pl/edu/pjatk/lnpayments/webservice/common/config/LoggerConfig.java
@@ -1,0 +1,20 @@
+package pl.edu.pjatk.lnpayments.webservice.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.filter.CommonsRequestLoggingFilter;
+
+@Configuration
+public class LoggerConfig {
+
+    @Bean
+    public CommonsRequestLoggingFilter requestLogFilter() {
+        CommonsRequestLoggingFilter filter = new CommonsRequestLoggingFilter();
+        filter.setIncludeClientInfo(true);
+        filter.setIncludeQueryString(true);
+        filter.setIncludePayload(true);
+        filter.setIncludeHeaders(false);
+        filter.setMaxPayloadLength(64000);
+        return filter;
+    }
+}

--- a/webservice/src/main/resources/application.properties
+++ b/webservice/src/main/resources/application.properties
@@ -7,6 +7,8 @@ spring.jpa.hibernate.ddl-auto=update
 spring.jpa.generate-ddl=true
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQL10Dialect
 
+logging.level.org.springframework.web.filter.CommonsRequestLoggingFilter=DEBUG
+
 spring.mvc.pathmatch.matching-strategy=ant_path_matcher
 
 server.servlet.context-path=/api


### PR DESCRIPTION
Link to the Jira issue
https://candybear.atlassian.net/browse/LP-196

### Description

Configured basic spring request logging. Many useful features are missing, but to implement proper logging of request/response with bodies and stuff requires much more effort (like 3 points). I think that it will do the job for us as we are almost done with implementation. 

### How did I test it

Loggs are visible in console.